### PR TITLE
Gracefully deprecate `label` keys instead of just breaking.

### DIFF
--- a/js/src/Zone.js
+++ b/js/src/Zone.js
@@ -21,6 +21,18 @@ export default class Zone {
     // name to be used for UserTiming measures
     this.measureName = config.name;
 
+    // handling deprecated "label" keys in backwards-compatible way
+    if (config.label) {
+      console.warn(
+        "[ux-capture] Deprecation Warning: `label` keys on configuration object were renamed to `name` as of verision v2.0.0",
+        "Will be removed in v3.0.0"
+      );
+
+      if (!config.name) {
+        this.measureName = config.label;
+      }
+    }
+
     // callback to execute when Zone is complete
     this.onMeasure = config.onMeasure;
 


### PR DESCRIPTION
Use old `label` keys if `name` keys are not available, will remove with next major version bump.

Send a deprecation warning into console to help with upgrade path.