### PR TITLE
WP-823 UXCapture.startTransition() Implementation

### DIFF
--- a/src/InteractiveView.js
+++ b/src/InteractiveView.js
@@ -3,16 +3,12 @@ import View from './View';
 const INTERACTIVE_NAVIGATION_START_MARK_NAME = 'transitionStart';
 
 export default class InteractiveView extends View {
-	startMark = null;
+	startMarkName = null;
 
 	startTransition() {
 		window.performance.mark(INTERACTIVE_NAVIGATION_START_MARK_NAME);
 
-		const allStartMarks = window.performance.getEntriesByName(
-			INTERACTIVE_NAVIGATION_START_MARK_NAME
-		);
-
 		// last one is the one we just created above, keep it
-		this.startMark = allStartMarks[allStartMarks.length - 1];
+		this.startMarkName = INTERACTIVE_NAVIGATION_START_MARK_NAME;
 	}
 }

--- a/src/InteractiveView.js
+++ b/src/InteractiveView.js
@@ -14,7 +14,5 @@ export default class InteractiveView extends View {
 
 		// last one is the one we just created above, keep it
 		this.startMark = allStartMarks[allStartMarks.length - 1];
-
-		super.startTransition();
 	}
 }

--- a/src/InteractiveView.js
+++ b/src/InteractiveView.js
@@ -1,0 +1,20 @@
+import View from './View';
+
+const INTERACTIVE_NAVIGATION_START_MARK_NAME = 'transitionStart';
+
+export default class InteractiveView extends View {
+	startMark = null;
+
+	startTransition() {
+		window.performance.mark(INTERACTIVE_NAVIGATION_START_MARK_NAME);
+
+		const allStartMarks = window.performance.getEntriesByName(
+			INTERACTIVE_NAVIGATION_START_MARK_NAME
+		);
+
+		// last one is the one we just created above, keep it
+		this.startMark = allStartMarks[allStartMarks.length - 1];
+
+		super.startTransition();
+	}
+}

--- a/src/PageView.js
+++ b/src/PageView.js
@@ -1,0 +1,11 @@
+import View from './View';
+
+export default class PageView extends View {
+	/**
+	 * Special type of mark that is going to be looked up in
+	 * performance.navigation.timing.navigationStart instead of PerformanceTimeline
+	 *
+	 * See: https://github.com/w3c/user-timing/issues/22
+	 */
+	startMark = 'navigationStart';
+}

--- a/src/PageView.js
+++ b/src/PageView.js
@@ -7,5 +7,5 @@ export default class PageView extends View {
 	 *
 	 * See: https://github.com/w3c/user-timing/issues/22
 	 */
-	startMark = 'navigationStart';
+	startMarkName = 'navigationStart';
 }

--- a/src/UXCapture.js
+++ b/src/UXCapture.js
@@ -58,6 +58,9 @@ const UXCapture = {
 	},
 
 	startTransition: () => {
+		window.performance.clearMarks();
+		window.performance.clearMeasures();
+
 		_view.startTransition();
 	},
 

--- a/src/UXCapture.js
+++ b/src/UXCapture.js
@@ -9,6 +9,11 @@ let _onMeasure;
 let _view;
 
 const UXCapture = {
+	_clearMarksAndMeasures: () => {
+		window.performance.clearMarks();
+		window.performance.clearMeasures();
+	},
+
 	/**
 	 * Sets `onMark` and `onMeasure` callbacks on UXCapture singleton
 	 * Also resets the view (supposed to be called once per page anyway)
@@ -58,8 +63,7 @@ const UXCapture = {
 	},
 
 	startTransition: () => {
-		window.performance.clearMarks();
-		window.performance.clearMeasures();
+		UXCapture._clearMarksAndMeasures();
 
 		_view.startTransition();
 	},

--- a/src/View.js
+++ b/src/View.js
@@ -30,16 +30,4 @@ export default class View extends UXBase {
 			...zoneConfig,
 		});
 	}
-
-	startTransition() {
-		window.performance
-			.getEntriesByType('mark')
-			.filter(mark => mark.name.startsWith('ux-'))
-			.forEach(mark => window.performance.clearMarks(mark));
-
-		window.performance
-			.getEntriesByType('measure')
-			.filter(measure => measure.name.startsWith('ux-'))
-			.forEach(measure => window.performance.clearMeasures(measure));
-	}
 }

--- a/src/View.js
+++ b/src/View.js
@@ -24,9 +24,22 @@ export default class View extends UXBase {
 
 	createZone(zoneConfig) {
 		return new Zone({
+			view: this,
 			onMark: this.props.onMark,
 			onMeasure: this.props.onMeasure,
 			...zoneConfig,
 		});
+	}
+
+	startTransition() {
+		window.performance
+			.getEntriesByType('mark')
+			.filter(mark => mark.name.startsWith('ux-'))
+			.forEach(mark => window.performance.clearMarks(mark));
+
+		window.performance
+			.getEntriesByType('measure')
+			.filter(measure => measure.name.startsWith('ux-'))
+			.forEach(measure => window.performance.clearMeasures(measure));
 	}
 }

--- a/src/Zone.js
+++ b/src/Zone.js
@@ -10,15 +10,14 @@ import UXBase from './UXBase';
  * {
  *  name: "ux-destination-verified",
  *  marks: ["ux-image-online-logo", "ux-image-inline-logo"]
- *  onMeasure: measureName => {}
- *  onMark: markName => {}
+ *  onMeasure: measureName => {},
+ *  onMark: markName => {},
+ *  view: View()
  * }
  */
 export default class Zone extends UXBase {
 	// Name used for UserTiming measures
 	measureName = this.props.name;
-
-	startMark = 'navigationStart';
 
 	// Create a new `ExpectedMark` for each mark
 	marks = this.props.marks.map(markName => {
@@ -35,17 +34,27 @@ export default class Zone extends UXBase {
 		return mark;
 	});
 
+	// Parent View object this zone belongs to
+	view = this.props.view;
+
 	/**
 	 * Records measure on Performance Timeline and calls onMeasure callback
 	 *
 	 * @param {ExpectedMark} lastMark last mark that triggered completion
 	 */
 	measure(endMarkName) {
+		if (!this.view.startMark) {
+			throw new Error(
+				`[UX Capture] Call to measure a zone in the view before view was started using startTransition() method.
+				Measure: ${this.measureName} Mark: ${endMarkName}`
+			);
+		}
+
 		if (
 			typeof window.performance !== 'undefined' &&
 			typeof window.performance.measure !== 'undefined'
 		) {
-			window.performance.measure(this.measureName, this.startMark, endMarkName);
+			window.performance.measure(this.measureName, this.view.startMark, endMarkName);
 		}
 
 		this.props.onMeasure(this.measureName);

--- a/src/Zone.js
+++ b/src/Zone.js
@@ -43,7 +43,7 @@ export default class Zone extends UXBase {
 	 * @param {ExpectedMark} lastMark last mark that triggered completion
 	 */
 	measure(endMarkName) {
-		if (!this.view.startMark) {
+		if (!this.view.startMarkName) {
 			throw new Error(
 				`[UX Capture] Call to measure a zone in the view before view was started using startTransition() method.
 				Measure: ${this.measureName} Mark: ${endMarkName}`
@@ -54,7 +54,11 @@ export default class Zone extends UXBase {
 			typeof window.performance !== 'undefined' &&
 			typeof window.performance.measure !== 'undefined'
 		) {
-			window.performance.measure(this.measureName, this.view.startMark, endMarkName);
+			window.performance.measure(
+				this.measureName,
+				this.view.startMarkName,
+				endMarkName
+			);
 		}
 
 		this.props.onMeasure(this.measureName);

--- a/test/uxCapture.test.js
+++ b/test/uxCapture.test.js
@@ -32,17 +32,15 @@ const onMeasure = jest.fn();
 
 describe('UXCapture', () => {
 	describe('startView', () => {
-		beforeAll(() => {
-			UXCapture.create({
-				onMark,
-				onMeasure,
-			});
-		});
-
 		beforeEach(() => {
 			ExpectedMark.clearExpectedMarks();
 			onMark.mockClear();
 			onMeasure.mockClear();
+
+			UXCapture.create({
+				onMark,
+				onMeasure,
+			});
 		});
 
 		it('must create dependencies between marks and measures', () => {
@@ -91,6 +89,11 @@ describe('UXCapture', () => {
 			ExpectedMark.clearExpectedMarks();
 			onMark.mockClear();
 			onMeasure.mockClear();
+
+			UXCapture.create({
+				onMark,
+				onMeasure,
+			});
 		});
 
 		it('Should throw an error if non-object is passed', () => {
@@ -161,6 +164,11 @@ describe('UXCapture', () => {
 			ExpectedMark.clearExpectedMarks();
 			onMark.mockClear();
 			onMeasure.mockClear();
+
+			UXCapture.create({
+				onMark,
+				onMeasure,
+			});
 
 			UXCapture.startView([
 				{

--- a/test/uxCapture.test.js
+++ b/test/uxCapture.test.js
@@ -37,10 +37,7 @@ describe('UXCapture', () => {
 			onMark.mockClear();
 			onMeasure.mockClear();
 
-			UXCapture.create({
-				onMark,
-				onMeasure,
-			});
+			UXCapture.create({ onMark, onMeasure });
 		});
 
 		it('must create dependencies between marks and measures', () => {
@@ -90,10 +87,7 @@ describe('UXCapture', () => {
 			onMark.mockClear();
 			onMeasure.mockClear();
 
-			UXCapture.create({
-				onMark,
-				onMeasure,
-			});
+			UXCapture.create({ onMark, onMeasure });
 		});
 
 		it('Should throw an error if non-object is passed', () => {
@@ -156,20 +150,12 @@ describe('UXCapture', () => {
 	});
 
 	describe('mark', () => {
-		beforeAll(() => {
-			UXCapture.create({ onMark, onMeasure });
-		});
-
 		beforeEach(() => {
 			ExpectedMark.clearExpectedMarks();
 			onMark.mockClear();
 			onMeasure.mockClear();
 
-			UXCapture.create({
-				onMark,
-				onMeasure,
-			});
-
+			UXCapture.create({ onMark, onMeasure });
 			UXCapture.startView([
 				{
 					name: MOCK_MEASURE_1,
@@ -260,6 +246,42 @@ describe('UXCapture', () => {
 					.getEntriesByType('measure')
 					.find(measure => measure.name === MOCK_MEASURE_1)
 			).toBeTruthy();
+		});
+	});
+
+	describe('startTransition', () => {
+		beforeEach(() => {
+			ExpectedMark.clearExpectedMarks();
+			onMark.mockClear();
+			onMeasure.mockClear();
+
+			UXCapture.create({ onMark, onMeasure });
+		});
+
+		it('shoulw work only on interactive views', () => {
+			// page view
+			UXCapture.startView([
+				{
+					name: MOCK_MEASURE_1,
+					marks: [MOCK_MARK_1_1, MOCK_MARK_1_2],
+				},
+			]);
+
+			expect(() => {
+				UXCapture.startTransition();
+			}).toThrow();
+
+			// interactive view
+			UXCapture.startView([
+				{
+					name: MOCK_MEASURE_1,
+					marks: [MOCK_MARK_1_1, MOCK_MARK_1_2],
+				},
+			]);
+
+			expect(() => {
+				UXCapture.startTransition();
+			}).not.toThrow();
 		});
 	});
 });

--- a/test/uxCapture.test.js
+++ b/test/uxCapture.test.js
@@ -38,6 +38,8 @@ describe('UXCapture', () => {
 			onMeasure.mockClear();
 
 			UXCapture.create({ onMark, onMeasure });
+
+			UXCapture._clearMarksAndMeasures();
 		});
 
 		it('must create dependencies between marks and measures', () => {
@@ -88,6 +90,8 @@ describe('UXCapture', () => {
 			onMeasure.mockClear();
 
 			UXCapture.create({ onMark, onMeasure });
+
+			UXCapture._clearMarksAndMeasures();
 		});
 
 		it('Should throw an error if non-object is passed', () => {
@@ -170,6 +174,8 @@ describe('UXCapture', () => {
 					marks: [MOCK_MARK_MULTIPLE],
 				},
 			]);
+
+			UXCapture._clearMarksAndMeasures();
 		});
 
 		it('must mark user timing api timeline', () => {
@@ -241,6 +247,8 @@ describe('UXCapture', () => {
 					.find(mark => mark.name === MOCK_MARK_1_1)
 			).toBeTruthy();
 
+			UXCapture.mark(MOCK_MARK_1_2, false);
+
 			expect(
 				window.performance
 					.getEntriesByType('measure')
@@ -256,6 +264,8 @@ describe('UXCapture', () => {
 			onMeasure.mockClear();
 
 			UXCapture.create({ onMark, onMeasure });
+
+			UXCapture._clearMarksAndMeasures();
 		});
 
 		it('shoulw work only on interactive views', () => {

--- a/test/uxCapture.test.js
+++ b/test/uxCapture.test.js
@@ -293,5 +293,74 @@ describe('UXCapture', () => {
 				UXCapture.startTransition();
 			}).not.toThrow();
 		});
+
+		it('should throw an error if measure is to be recorded before view has started', () => {
+			// page view
+			UXCapture.startView([
+				{
+					name: MOCK_MEASURE_1,
+					marks: [MOCK_MARK_1_1, MOCK_MARK_1_2],
+				},
+			]);
+
+			// interactive view
+			UXCapture.startView([
+				{
+					name: MOCK_MEASURE_1,
+					marks: [MOCK_MARK_1_1, MOCK_MARK_1_2],
+				},
+			]);
+
+			expect(() => {
+				// mark 1 in page view
+				UXCapture.mark(MOCK_MARK_1_1);
+				UXCapture.mark(MOCK_MARK_1_2);
+			}).toThrow();
+		});
+
+		it('must keep only one mark after interactive view started transition', () => {
+			// page view 1
+			UXCapture.startView([
+				{
+					name: MOCK_MEASURE_1,
+					marks: [MOCK_MARK_1_1, MOCK_MARK_1_2],
+				},
+				{
+					name: MOCK_MEASURE_2,
+					marks: [MOCK_MARK_MULTIPLE],
+				},
+				{
+					name: MOCK_MEASURE_3,
+					marks: [MOCK_MARK_MULTIPLE],
+				},
+			]);
+
+			// mark 1 in page view
+			UXCapture.mark(MOCK_MARK_1_1);
+			UXCapture.mark(MOCK_MARK_1_2);
+
+			expect(window.performance.getEntriesByType('mark').length).toBe(2);
+			expect(window.performance.getEntriesByType('measure').length).toBe(1);
+
+			// interactive view 1
+			UXCapture.startView([
+				{
+					name: MOCK_MEASURE_1,
+					marks: [MOCK_MARK_1_1, MOCK_MARK_1_2],
+				},
+			]);
+
+			// starting transition in interactive view 1
+			UXCapture.startTransition();
+
+			// mark 1 in interactive view
+			UXCapture.mark(MOCK_MARK_1_1);
+
+			expect(
+				window.performance
+					.getEntriesByType('mark')
+					.filter(mark => mark.name === MOCK_MARK_1_1).length
+			).toBe(1);
+		});
 	});
 });

--- a/test/uxCapture.test.js
+++ b/test/uxCapture.test.js
@@ -14,9 +14,6 @@ window.performance.timing = {
 window.requestAnimationFrame = jest.fn(cb => cb());
 window.setTimeout = jest.fn(cb => cb());
 
-// using console.timeStamp for testing only
-console.timeStamp = jest.fn();
-
 const MOCK_MEASURE_1 = 'ux-mock-measure_1';
 const MOCK_MARK_1_1 = 'ux-mock-mark_1_1';
 const MOCK_MARK_1_2 = 'ux-mock-mark_1_2';
@@ -199,8 +196,17 @@ describe('UXCapture', () => {
 			).toBeTruthy();
 		});
 
+		it('should not thrown an exception if console.timeStamp is not available', () => {
+			// console.timeStamp is not available in jsdom which Jest uses for testing
+			expect(() => {
+				// mark 1 in page view
+				UXCapture.mark(MOCK_MARK_1_1);
+			}).not.toThrow();
+		});
+
 		it("should fire a console.timeStamp if it's available", () => {
-			console.timeStamp.mockClear();
+			// define console.timeStamp for testing only
+			console.timeStamp = jest.fn();
 
 			UXCapture.mark(MOCK_MARK_1_1);
 


### PR DESCRIPTION
Implemented `UXCapture.startTransition()` function used in SPA applications.

Created `PageView` and `InteractiveView` classes to represent each type of view separately and to manage startMarkName property differently.

Also added private `UXCapture._clearMarksAndMeasures()` method for clearing all pre-exisiting marks and measures. Calling it in `UXCapture.startTransition()`, but can also be useful in tests.

JIRA: https://meetup.atlassian.net/browse/WP-823

P.S. our API creates gap between starting new view with `UXCapture.startView()` and starting transition with `UXCapture.startTransition()` - during this time no marks should be fired (as interactive transition start mark hasn't been fired yet and is `null`). This is not great as we don't really control when they fire (e.g. onload events for images, for example). We can also keep view "un-attached" until it's started so all marks during this gap time are accounted towards previous view. Thoughts?