### PR TITLE
WP-946 Selectors

### DIFF
--- a/examples/micro_spa.js
+++ b/examples/micro_spa.js
@@ -1,0 +1,52 @@
+// emulating a long-running JS event attachment, e.g. React re-hydration
+setTimeout(() => {
+	document.getElementById('morelink').addEventListener('click', function(e) {
+		e.preventDefault();
+
+		alert('More kittens there');
+	});
+
+	window.UXCapture.mark('ux-handler-moreclickable');
+}, 300);
+
+// mini-SPA
+document.querySelector('a[href="page2.html"]').addEventListener('click', e => {
+	e.preventDefault();
+
+	// triggers initial mark
+	UXCapture.startTransition();
+
+	document.getElementById('content').innerHTML = '<i>... loading page 2 ...</i>';
+
+	setTimeout(() => {
+		// sets new view expectations
+		UXCapture.startView([
+			{
+				name: 'ux-destination-verified',
+				elements: [
+					{
+						marks: ['ux-text-title'],
+						// CSS selector, same as () => document.querySelectorAll('h1')
+						elementSelector: 'h1',
+					},
+				],
+			},
+			{
+				name: 'ux-primary-content-displayed',
+				elements: [
+					{
+						marks: ['ux-text-page2-content'],
+						elementSelector: '#page2content',
+					},
+				],
+			},
+		]);
+
+		setTimeout(() => {
+			document.getElementById('content').innerHTML =
+				'<p id="page2content">SPA transition to page 2 successful</p>';
+
+			UXCapture.mark('ux-text-page2-content');
+		}, 900); // 1s delay between startTransition() and Primary Content Available
+	}, 100); // 100ms delay between startTransition() and startView();
+});

--- a/examples/selectors-elementtiming.html
+++ b/examples/selectors-elementtiming.html
@@ -110,6 +110,8 @@
 				},
 			]);
 		</script>
+
+		<script src="micro_spa.js" async></script>
 	</head>
 
 	<body>
@@ -178,61 +180,5 @@
 				window.UXCapture.mark('ux-text-page2');
 			</script>
 		</div>
-
-		<script>
-			// emulating a long-running JS event attachment, e.g. React re-hydration
-			setTimeout(() => {
-				document.getElementById('morelink').addEventListener('click', function(e) {
-					e.preventDefault();
-
-					alert('More kittens there');
-				});
-
-				window.UXCapture.mark('ux-handler-moreclickable');
-			}, 300);
-
-			// mini-SPA
-			document.querySelector('a[href="page2.html"]').addEventListener('click', e => {
-				e.preventDefault();
-
-				// triggers initial mark
-				UXCapture.startTransition();
-
-				document.getElementById('content').innerHTML =
-					'<i>... loading page 2 ...</i>';
-
-				setTimeout(() => {
-					// sets new view expectations
-					UXCapture.startView([
-						{
-							name: 'ux-destination-verified',
-							elements: [
-								{
-									marks: ['ux-text-title'],
-									// CSS selector, same as () => document.querySelectorAll('h1')
-									elementSelector: 'h1',
-								},
-							],
-						},
-						{
-							name: 'ux-primary-content-displayed',
-							elements: [
-								{
-									marks: ['ux-text-page2-content'],
-									elementSelector: '#page2content',
-								},
-							],
-						},
-					]);
-
-					setTimeout(() => {
-						document.getElementById('content').innerHTML =
-							'<p id="page2content">SPA transition to page 2 successful</p>';
-
-						UXCapture.mark('ux-text-page2-content');
-					}, 900); // 1s delay between startTransition() and Primary Content Available
-				}, 100); // 100ms delay between startTransition() and startView();
-			});
-		</script>
 	</body>
 </html>

--- a/examples/selectors-elementtiming.html
+++ b/examples/selectors-elementtiming.html
@@ -117,90 +117,67 @@
 		<script>
 			window.UXCapture.mark('ux-text-title');
 		</script>
-
-		<p elementtiming="intro">
-			<img
-				elementtiming="kitten"
-				src="kitten.jpg"
-				style="float: left; margin: 0 1em 1em 0"
-				width="30%"
-				onload="window.UXCapture.mark('ux-image-onload-kitten')"
-			/>
+		<div id="content">
+			<p elementtiming="intro">
+				<img
+					elementtiming="kitten"
+					src="kitten.jpg"
+					style="float: left; margin: 0 1em 1em 0"
+					width="30%"
+					onload="window.UXCapture.mark('ux-image-onload-kitten')"
+				/>
+				<script>
+					window.UXCapture.mark('ux-image-inline-kitten');
+				</script>
+				Decide to want nothing to do with my owner today. When in doubt, wash being
+				gorgeous with belly side up sweet beast, but poop in the plant pot but munch
+				on tasty moths. Brown cats with pink ears. Caticus cuteicus when in doubt,
+				wash stare at ceiling, and scream at teh bath, lies down but cough hairball on
+				conveniently placed pants claw your carpet in places everyone can see - why
+				hide my amazing artistic clawing skills?. Meow in empty rooms.
+			</p>
 			<script>
-				window.UXCapture.mark('ux-image-inline-kitten');
+				window.UXCapture.mark('ux-text-intro');
 			</script>
-			Decide to want nothing to do with my owner today. When in doubt, wash being
-			gorgeous with belly side up sweet beast, but poop in the plant pot but munch on
-			tasty moths. Brown cats with pink ears. Caticus cuteicus when in doubt, wash
-			stare at ceiling, and scream at teh bath, lies down but cough hairball on
-			conveniently placed pants claw your carpet in places everyone can see - why hide
-			my amazing artistic clawing skills?. Meow in empty rooms.
-		</p>
-		<script>
-			window.UXCapture.mark('ux-text-intro');
-		</script>
 
-		<script>
-			// delaying this loop a tiny bit to show the difference
-			var y = 0;
-
-			for (var i = 0; i < 100000; i++) {
-				y += i;
-			}
-		</script>
-
-		<p elementtiming="story">
-			Bacon ipsum dolor amet jowl swine brisket, drumstick pig chicken meatball ham
-			hock ham salami andouille hamburger. Ribeye alcatra porchetta flank. Venison
-			chicken meatloaf landjaeger. Porchetta burgdoggen ham hock, pork belly beef ribs
-			chicken meatloaf jowl strip steak t-bone. Pork chop turducken drumstick kevin
-			leberkas jowl chicken prosciutto salami meatloaf, tri-tip doner boudin ground
-			round <a href="story-details.html" elementtiming="details">read more...</a>
 			<script>
-				window.UXCapture.mark('ux-text-story-details-link');
+				// delaying this loop a tiny bit to show the difference
+				var y = 0;
+
+				for (var i = 0; i < 100000; i++) {
+					y += i;
+				}
 			</script>
-		</p>
-		<script>
-			window.UXCapture.mark('ux-text-story');
-		</script>
 
-		<p>
-			Suscipit anim. Fugit quaerat. Incididunt nesciunt. Cupidatat cillum sed. Laborum
-			totam and dolores sit. Commodi eos yet laboris. Dolorem cillum, excepteur yet
-			incididunt velit numquam. Ipsam error. Ratione consequuntur for magni ratione
-			and incididunt sit. Esse inventore yet nostrud so nesciunt, eius. Ratione
-			molestiae, autem, and dicta. Nostrud laboris labore, so nulla illum. Dolor totam
-			inventore iure yet omnis ipsam incidunt. Eiusmod beatae or ipsam, dolore.
-			Doloremque exercitationem. Error. Error modi. Ipsam ipsum or labore or ab
-			aspernatur. Aliquip. Laudantium voluptas eaque for eius, yet laboris sed so
-			dicta. Suscipit natus for eum veniam totam, for anim so fugiat. Suscipit
-			explicabo and cillum or rem explicabo. Sint vel eiusmod labore, or dolor so
-			nostrud for quae.
-		</p>
-		<p>
-			Aliquid velit but odit error. Aute cupidatat or beatae. Voluptas in
-			consequuntur. Incidunt vel, and consectetur. Numquam ipsa and est or dolorem so
-			amet. Aliqua ea molestiae labore for eiusmod eu commodo. Est nequeporro so
-			fugiat laborum laboriosam and nequeporro. Eu id yet irure so numquam yet
-			exercitation. Fugit fugiat dicta for aliquip, and iure. Vel consequatur modi. Ut
-			adipisicing yet nisi suscipit aute. Consequat esse laudantium. Amet cillum nisi
-			so ipsam ad minima but dolore. Aperiam adipisci eum quo do. Sed ex and nisi quo
-			quae quo for explicabo. Proident nesciunt for aliquid ratione. Occaecat
-			consequat for enim quia eos quis, tempor. Lorem perspiciatis. Dolore eius
-			consequatur error but minim. Pariatur cillum, ipsum explicabo but nemo. Aliquid
-			molestiae so aliqua. Omnis commodo. Voluptas. Error proident, but lorem aperiam.
-			Magnam quia laborum.
-		</p>
-		<p>
-			Lorem non. Aperiam exercitationem omnis. Consequatur rem labore architecto. Ad
-			molestiae explicabo but nemo for doloremque. Aliquip dolor, yet velitesse so
-			omnis vitae aspernatur. Modi. Aliqua.
-		</p>
+			<p elementtiming="story">
+				Bacon ipsum dolor amet jowl swine brisket, drumstick pig chicken meatball ham
+				hock ham salami andouille hamburger. Ribeye alcatra porchetta flank. Venison
+				chicken meatloaf landjaeger. Porchetta burgdoggen ham hock, pork belly beef
+				ribs chicken meatloaf jowl strip steak t-bone. Pork chop turducken drumstick
+				kevin leberkas jowl chicken prosciutto salami meatloaf, tri-tip doner boudin
+				ground round
+				<a href="story-details.html" id="morelink" elementtiming="details"
+					>read more...</a
+				>
+				<script>
+					window.UXCapture.mark('ux-text-story-details-link');
+				</script>
+			</p>
+			<script>
+				window.UXCapture.mark('ux-text-story');
+			</script>
 
-		<a href="page2.html" elementtiming="page2-link">Page 2 &gt; &gt;</a>
-		<script>
-			window.UXCapture.mark('ux-text-page2');
-		</script>
+			<p>
+				Lorem non. Aperiam exercitationem omnis. Consequatur rem labore architecto. Ad
+				molestiae explicabo but nemo for doloremque. Aliquip dolor, yet velitesse so
+				omnis vitae aspernatur. Modi. Aliqua.
+			</p>
+
+			<a href="page2.html" elementtiming="page2-link">Page 2 &gt; &gt;</a>
+			<script>
+				window.UXCapture.mark('ux-text-page2');
+			</script>
+		</div>
 
 		<script>
 			// emulating a long-running JS event attachment, e.g. React re-hydration
@@ -213,6 +190,49 @@
 
 				window.UXCapture.mark('ux-handler-moreclickable');
 			}, 300);
+
+			// mini-SPA
+			document.querySelector('a[href="page2.html"]').addEventListener('click', e => {
+				e.preventDefault();
+
+				// triggers initial mark
+				UXCapture.startTransition();
+
+				document.getElementById('content').innerHTML =
+					'<i>... loading page 2 ...</i>';
+
+				setTimeout(() => {
+					// sets new view expectations
+					UXCapture.startView([
+						{
+							name: 'ux-destination-verified',
+							elements: [
+								{
+									marks: ['ux-text-title'],
+									// CSS selector, same as () => document.querySelectorAll('h1')
+									elementSelector: 'h1',
+								},
+							],
+						},
+						{
+							name: 'ux-primary-content-displayed',
+							elements: [
+								{
+									marks: ['ux-text-page2-content'],
+									elementSelector: '#page2content',
+								},
+							],
+						},
+					]);
+
+					setTimeout(() => {
+						document.getElementById('content').innerHTML =
+							'<p id="page2content">SPA transition to page 2 successful</p>';
+
+						UXCapture.mark('ux-text-page2-content');
+					}, 900); // 1s delay between startTransition() and Primary Content Available
+				}, 100); // 100ms delay between startTransition() and startView();
+			});
 		</script>
 	</body>
 </html>

--- a/examples/selectors-elementtiming.html
+++ b/examples/selectors-elementtiming.html
@@ -1,0 +1,218 @@
+<html>
+	<head>
+		<title>Sample Page | UX capture</title>
+
+		<!-- don't do this in production, but inline it instead -->
+		<script src="../lib/ux-capture.min.js"></script>
+
+		<script>
+			// sample custom reporter function for collected measures
+			const customMeasureRecordingFunction = name => {
+				// there can be multiple entries with the same name, get the latest
+				const measure = performance
+					.getEntriesByType('measure')
+					.filter(entry => entry.name === name)
+					.pop();
+
+				if (typeof measure.duration !== 'undefined') {
+					// in real world you might be sending this to your custom monitoring solution
+					// (because it does not support W3C UserTiming API natively)
+					console.log('Measure', name, ':', measure.duration);
+				}
+			};
+
+			// universal selector used for all zones
+			// this can encorporate established site-wide pattern like using classes to denote elements
+			const universalElementSelector = element =>
+				document.querySelectorAll(`[elementtiming="${element.name}]"`);
+
+			window.UXCapture.create({
+				onMeasure: customMeasureRecordingFunction,
+				elementSelector: universalElementSelector,
+			});
+
+			/**
+			 * Array of zone objects groupping elements together
+			 *
+			 * window.UXCapture.startView([
+			 * {
+			 *  name: "ux-destination-verified",
+			 *  elements: ...
+			 * }
+			 * ]);
+			 *
+			 * Using elements array with elementSelector and optional expectedElements properties
+			 * will allow you to automatically detect already rendered elements and zones during startView() call
+			 * in interactive views.
+			 *
+			 * Each element is marked using UserTiming and selectors
+			 * elements: [{
+			 *  // [<string>] - names of marks to expect for this element
+			 *  marks: ["ux-image-logo-onload", "ux-image-logo-inline"],
+			 *
+			 *  // <string|function> - string is an input to document.querySelectorAll()
+			 *  //                     or function that returns a collection of DOM nodes.
+			 *  // Used to detect if elements are already on the page on SPA transition
+			 *  // and for highlighting during debugging
+			 *  elementSelector: "h1",
+			 *
+			 *  // <number|function> - number is used to compare to return of elementSelector
+			 *  //                     or function that returns a boolean indicating if element
+			 *  //                     is already displayed and functional
+			 *  // default: 1
+			 *  expectedElements: 2
+			 * }]
+			 */
+			window.UXCapture.startView([
+				{
+					name: 'ux-destination-verified',
+					elements: [
+						{
+							name: 'title',
+							marks: ['ux-text-title'],
+						},
+					],
+				},
+				{
+					name: 'ux-primary-content-displayed',
+					elements: [
+						{
+							name: 'intro',
+							marks: ['ux-text-intro'],
+						},
+						{
+							name: 'story',
+							marks: ['ux-text-story'],
+						},
+						{
+							name: 'kitten',
+							marks: ['ux-image-onload-kitten', 'ux-image-inline-kitten'],
+						},
+					],
+				},
+				{
+					name: 'ux-primary-action-available',
+					elements: [
+						{
+							name: 'details',
+							marks: ['ux-text-story-details-link', 'ux-handler-moreclickable'],
+						},
+					],
+				},
+				{
+					name: 'ux-secondary-content-displayed',
+					elements: [
+						{
+							name: 'page2-link',
+							marks: ['ux-text-page2'],
+						},
+					],
+				},
+			]);
+		</script>
+	</head>
+
+	<body>
+		<h1 elementtiming="title">UX Capture library sample page</h1>
+		<script>
+			window.UXCapture.mark('ux-text-title');
+		</script>
+
+		<p elementtiming="intro">
+			<img
+				elementtiming="kitten"
+				src="kitten.jpg"
+				style="float: left; margin: 0 1em 1em 0"
+				width="30%"
+				onload="window.UXCapture.mark('ux-image-onload-kitten')"
+			/>
+			<script>
+				window.UXCapture.mark('ux-image-inline-kitten');
+			</script>
+			Decide to want nothing to do with my owner today. When in doubt, wash being
+			gorgeous with belly side up sweet beast, but poop in the plant pot but munch on
+			tasty moths. Brown cats with pink ears. Caticus cuteicus when in doubt, wash
+			stare at ceiling, and scream at teh bath, lies down but cough hairball on
+			conveniently placed pants claw your carpet in places everyone can see - why hide
+			my amazing artistic clawing skills?. Meow in empty rooms.
+		</p>
+		<script>
+			window.UXCapture.mark('ux-text-intro');
+		</script>
+
+		<script>
+			// delaying this loop a tiny bit to show the difference
+			var y = 0;
+
+			for (var i = 0; i < 100000; i++) {
+				y += i;
+			}
+		</script>
+
+		<p elementtiming="story">
+			Bacon ipsum dolor amet jowl swine brisket, drumstick pig chicken meatball ham
+			hock ham salami andouille hamburger. Ribeye alcatra porchetta flank. Venison
+			chicken meatloaf landjaeger. Porchetta burgdoggen ham hock, pork belly beef ribs
+			chicken meatloaf jowl strip steak t-bone. Pork chop turducken drumstick kevin
+			leberkas jowl chicken prosciutto salami meatloaf, tri-tip doner boudin ground
+			round <a href="story-details.html" elementtiming="details">read more...</a>
+			<script>
+				window.UXCapture.mark('ux-text-story-details-link');
+			</script>
+		</p>
+		<script>
+			window.UXCapture.mark('ux-text-story');
+		</script>
+
+		<p>
+			Suscipit anim. Fugit quaerat. Incididunt nesciunt. Cupidatat cillum sed. Laborum
+			totam and dolores sit. Commodi eos yet laboris. Dolorem cillum, excepteur yet
+			incididunt velit numquam. Ipsam error. Ratione consequuntur for magni ratione
+			and incididunt sit. Esse inventore yet nostrud so nesciunt, eius. Ratione
+			molestiae, autem, and dicta. Nostrud laboris labore, so nulla illum. Dolor totam
+			inventore iure yet omnis ipsam incidunt. Eiusmod beatae or ipsam, dolore.
+			Doloremque exercitationem. Error. Error modi. Ipsam ipsum or labore or ab
+			aspernatur. Aliquip. Laudantium voluptas eaque for eius, yet laboris sed so
+			dicta. Suscipit natus for eum veniam totam, for anim so fugiat. Suscipit
+			explicabo and cillum or rem explicabo. Sint vel eiusmod labore, or dolor so
+			nostrud for quae.
+		</p>
+		<p>
+			Aliquid velit but odit error. Aute cupidatat or beatae. Voluptas in
+			consequuntur. Incidunt vel, and consectetur. Numquam ipsa and est or dolorem so
+			amet. Aliqua ea molestiae labore for eiusmod eu commodo. Est nequeporro so
+			fugiat laborum laboriosam and nequeporro. Eu id yet irure so numquam yet
+			exercitation. Fugit fugiat dicta for aliquip, and iure. Vel consequatur modi. Ut
+			adipisicing yet nisi suscipit aute. Consequat esse laudantium. Amet cillum nisi
+			so ipsam ad minima but dolore. Aperiam adipisci eum quo do. Sed ex and nisi quo
+			quae quo for explicabo. Proident nesciunt for aliquid ratione. Occaecat
+			consequat for enim quia eos quis, tempor. Lorem perspiciatis. Dolore eius
+			consequatur error but minim. Pariatur cillum, ipsum explicabo but nemo. Aliquid
+			molestiae so aliqua. Omnis commodo. Voluptas. Error proident, but lorem aperiam.
+			Magnam quia laborum.
+		</p>
+		<p>
+			Lorem non. Aperiam exercitationem omnis. Consequatur rem labore architecto. Ad
+			molestiae explicabo but nemo for doloremque. Aliquip dolor, yet velitesse so
+			omnis vitae aspernatur. Modi. Aliqua.
+		</p>
+
+		<a href="page2.html" elementtiming="page2-link">Page 2 &gt; &gt;</a>
+		<script>
+			window.UXCapture.mark('ux-text-page2');
+		</script>
+
+		<script>
+			// emulating a long-running JS event attachment, e.g. React re-hydration
+			setTimeout(() => {
+				document.getElementById('morelink').addEventListener('click', function(e) {
+					e.preventDefault();
+
+					alert('More kittens there');
+				});
+
+				window.UXCapture.mark('ux-handler-moreclickable');
+			}, 300);
+		</script>
+	</body>
+</html>

--- a/examples/selectors-mark-selector.html
+++ b/examples/selectors-mark-selector.html
@@ -1,0 +1,167 @@
+<html>
+	<head>
+		<title>Sample Page | UX capture</title>
+
+		<!-- don't do this in production, but inline it instead -->
+		<script src="../lib/ux-capture.min.js"></script>
+
+		<script>
+			// sample custom reporter function for collected measures
+			const customMeasureRecordingFunction = name => {
+				// there can be multiple entries with the same name, get the latest
+				const measure = performance
+					.getEntriesByType('measure')
+					.filter(entry => entry.name === name)
+					.pop();
+
+				if (typeof measure.duration !== 'undefined') {
+					// in real world you might be sending this to your custom monitoring solution
+					// (because it does not support W3C UserTiming API natively)
+					console.log('Measure', name, ':', measure.duration);
+				}
+			};
+
+			// just a function that used to detect if element we instrumented with a mark has already fired
+			const markSelector = markName => document.querySelectorAll(`.${markName}`);
+
+			window.UXCapture.create({
+				onMeasure: customMeasureRecordingFunction,
+				markSelector: markSelector,
+			});
+
+			window.UXCapture.startView([
+				{
+					name: 'ux-destination-verified',
+					marks: ['ux-text-title'],
+				},
+				{
+					name: 'ux-primary-content-displayed',
+					marks: [
+						'ux-text-intro',
+						'ux-text-story',
+						'ux-image-onload-kitten',
+						'ux-image-inline-kitten',
+					],
+				},
+				{
+					name: 'ux-primary-action-available',
+					marks: ['ux-text-story-details-link', 'ux-handler-moreclickable'],
+				},
+				{
+					name: 'ux-secondary-content-displayed',
+					marks: ['ux-text-page2'],
+				},
+			]);
+		</script>
+	</head>
+
+	<body>
+		<h1 class="ux-text-title">UX Capture library sample page</h1>
+		<script>
+			window.UXCapture.mark('ux-text-title');
+		</script>
+
+		<p class="ux-text-intro">
+			<img
+				src="kitten.jpg"
+				style="float: left; margin: 0 1em 1em 0"
+				width="30%"
+				onload="window.UXCapture.mark('ux-image-onload-kitten')"
+				class="ux-image-inline-kitten ux-image-onload-kitten"
+			/>
+			<script>
+				window.UXCapture.mark('ux-image-inline-kitten');
+			</script>
+			Decide to want nothing to do with my owner today. When in doubt, wash being
+			gorgeous with belly side up sweet beast, but poop in the plant pot but munch on
+			tasty moths. Brown cats with pink ears. Caticus cuteicus when in doubt, wash
+			stare at ceiling, and scream at teh bath, lies down but cough hairball on
+			conveniently placed pants claw your carpet in places everyone can see - why hide
+			my amazing artistic clawing skills?. Meow in empty rooms.
+		</p>
+		<script>
+			window.UXCapture.mark('ux-text-intro');
+		</script>
+
+		<script>
+			// delaying this loop a tiny bit to show the difference
+			var y = 0;
+
+			for (var i = 0; i < 100000; i++) {
+				y += i;
+			}
+		</script>
+
+		<p class="ux-text-story">
+			Bacon ipsum dolor amet jowl swine brisket, drumstick pig chicken meatball ham
+			hock ham salami andouille hamburger. Ribeye alcatra porchetta flank. Venison
+			chicken meatloaf landjaeger. Porchetta burgdoggen ham hock, pork belly beef ribs
+			chicken meatloaf jowl strip steak t-bone. Pork chop turducken drumstick kevin
+			leberkas jowl chicken prosciutto salami meatloaf, tri-tip doner boudin ground
+			round
+			<a
+				href="story-details.html"
+				class="ux-text-story-details-link ux-handler-moreclickable"
+				id="morelink"
+				>read more...</a
+			>
+			<script>
+				window.UXCapture.mark('ux-text-story-details-link');
+			</script>
+		</p>
+		<script>
+			window.UXCapture.mark('ux-text-story');
+		</script>
+
+		<p>
+			Suscipit anim. Fugit quaerat. Incididunt nesciunt. Cupidatat cillum sed. Laborum
+			totam and dolores sit. Commodi eos yet laboris. Dolorem cillum, excepteur yet
+			incididunt velit numquam. Ipsam error. Ratione consequuntur for magni ratione
+			and incididunt sit. Esse inventore yet nostrud so nesciunt, eius. Ratione
+			molestiae, autem, and dicta. Nostrud laboris labore, so nulla illum. Dolor totam
+			inventore iure yet omnis ipsam incidunt. Eiusmod beatae or ipsam, dolore.
+			Doloremque exercitationem. Error. Error modi. Ipsam ipsum or labore or ab
+			aspernatur. Aliquip. Laudantium voluptas eaque for eius, yet laboris sed so
+			dicta. Suscipit natus for eum veniam totam, for anim so fugiat. Suscipit
+			explicabo and cillum or rem explicabo. Sint vel eiusmod labore, or dolor so
+			nostrud for quae.
+		</p>
+		<p>
+			Aliquid velit but odit error. Aute cupidatat or beatae. Voluptas in
+			consequuntur. Incidunt vel, and consectetur. Numquam ipsa and est or dolorem so
+			amet. Aliqua ea molestiae labore for eiusmod eu commodo. Est nequeporro so
+			fugiat laborum laboriosam and nequeporro. Eu id yet irure so numquam yet
+			exercitation. Fugit fugiat dicta for aliquip, and iure. Vel consequatur modi. Ut
+			adipisicing yet nisi suscipit aute. Consequat esse laudantium. Amet cillum nisi
+			so ipsam ad minima but dolore. Aperiam adipisci eum quo do. Sed ex and nisi quo
+			quae quo for explicabo. Proident nesciunt for aliquid ratione. Occaecat
+			consequat for enim quia eos quis, tempor. Lorem perspiciatis. Dolore eius
+			consequatur error but minim. Pariatur cillum, ipsum explicabo but nemo. Aliquid
+			molestiae so aliqua. Omnis commodo. Voluptas. Error proident, but lorem aperiam.
+			Magnam quia laborum.
+		</p>
+		<p>
+			Lorem non. Aperiam exercitationem omnis. Consequatur rem labore architecto. Ad
+			molestiae explicabo but nemo for doloremque. Aliquip dolor, yet velitesse so
+			omnis vitae aspernatur. Modi. Aliqua.
+		</p>
+
+		<a href="page2.html" class="ux-text-page2">Page 2 &gt; &gt;</a>
+		<script>
+			window.UXCapture.mark('ux-text-page2');
+		</script>
+
+		<script>
+			// emulating a long-running JS event attachment, e.g. React re-hydration
+			setTimeout(() => {
+				document.getElementById('morelink').addEventListener('click', function(e) {
+					e.preventDefault();
+
+					alert('More kittens there');
+				});
+
+				window.UXCapture.mark('ux-handler-moreclickable');
+			}, 300);
+		</script>
+	</body>
+</html>

--- a/examples/selectors-mark-selector.html
+++ b/examples/selectors-mark-selector.html
@@ -53,6 +53,7 @@
 				},
 			]);
 		</script>
+		<script src="micro_spa.js" async></script>
 	</head>
 
 	<body>
@@ -125,61 +126,5 @@
 				window.UXCapture.mark('ux-text-page2');
 			</script>
 		</div>
-
-		<script>
-			// emulating a long-running JS event attachment, e.g. React re-hydration
-			setTimeout(() => {
-				document.getElementById('morelink').addEventListener('click', function(e) {
-					e.preventDefault();
-
-					alert('More kittens there');
-				});
-
-				window.UXCapture.mark('ux-handler-moreclickable');
-			}, 300);
-
-			// mini-SPA
-			document.querySelector('a[href="page2.html"]').addEventListener('click', e => {
-				e.preventDefault();
-
-				// triggers initial mark
-				UXCapture.startTransition();
-
-				document.getElementById('content').innerHTML =
-					'<i>... loading page 2 ...</i>';
-
-				setTimeout(() => {
-					// sets new view expectations
-					UXCapture.startView([
-						{
-							name: 'ux-destination-verified',
-							elements: [
-								{
-									marks: ['ux-text-title'],
-									// CSS selector, same as () => document.querySelectorAll('h1')
-									elementSelector: 'h1',
-								},
-							],
-						},
-						{
-							name: 'ux-primary-content-displayed',
-							elements: [
-								{
-									marks: ['ux-text-page2-content'],
-									elementSelector: '#page2content',
-								},
-							],
-						},
-					]);
-
-					setTimeout(() => {
-						document.getElementById('content').innerHTML =
-							'<p id="page2content">SPA transition to page 2 successful</p>';
-
-						UXCapture.mark('ux-text-page2-content');
-					}, 900); // 1s delay between startTransition() and Primary Content Available
-				}, 100); // 100ms delay between startTransition() and startView();
-			});
-		</script>
 	</body>
 </html>

--- a/examples/selectors-mark-selector.html
+++ b/examples/selectors-mark-selector.html
@@ -61,95 +61,70 @@
 			window.UXCapture.mark('ux-text-title');
 		</script>
 
-		<p class="ux-text-intro">
-			<img
-				src="kitten.jpg"
-				style="float: left; margin: 0 1em 1em 0"
-				width="30%"
-				onload="window.UXCapture.mark('ux-image-onload-kitten')"
-				class="ux-image-inline-kitten ux-image-onload-kitten"
-			/>
+		<div id="content">
+			<p class="ux-text-intro">
+				<img
+					src="kitten.jpg"
+					style="float: left; margin: 0 1em 1em 0"
+					width="30%"
+					onload="window.UXCapture.mark('ux-image-onload-kitten')"
+					class="ux-image-inline-kitten ux-image-onload-kitten"
+				/>
+				<script>
+					window.UXCapture.mark('ux-image-inline-kitten');
+				</script>
+				Decide to want nothing to do with my owner today. When in doubt, wash being
+				gorgeous with belly side up sweet beast, but poop in the plant pot but munch
+				on tasty moths. Brown cats with pink ears. Caticus cuteicus when in doubt,
+				wash stare at ceiling, and scream at teh bath, lies down but cough hairball on
+				conveniently placed pants claw your carpet in places everyone can see - why
+				hide my amazing artistic clawing skills?. Meow in empty rooms.
+			</p>
 			<script>
-				window.UXCapture.mark('ux-image-inline-kitten');
+				window.UXCapture.mark('ux-text-intro');
 			</script>
-			Decide to want nothing to do with my owner today. When in doubt, wash being
-			gorgeous with belly side up sweet beast, but poop in the plant pot but munch on
-			tasty moths. Brown cats with pink ears. Caticus cuteicus when in doubt, wash
-			stare at ceiling, and scream at teh bath, lies down but cough hairball on
-			conveniently placed pants claw your carpet in places everyone can see - why hide
-			my amazing artistic clawing skills?. Meow in empty rooms.
-		</p>
-		<script>
-			window.UXCapture.mark('ux-text-intro');
-		</script>
 
-		<script>
-			// delaying this loop a tiny bit to show the difference
-			var y = 0;
-
-			for (var i = 0; i < 100000; i++) {
-				y += i;
-			}
-		</script>
-
-		<p class="ux-text-story">
-			Bacon ipsum dolor amet jowl swine brisket, drumstick pig chicken meatball ham
-			hock ham salami andouille hamburger. Ribeye alcatra porchetta flank. Venison
-			chicken meatloaf landjaeger. Porchetta burgdoggen ham hock, pork belly beef ribs
-			chicken meatloaf jowl strip steak t-bone. Pork chop turducken drumstick kevin
-			leberkas jowl chicken prosciutto salami meatloaf, tri-tip doner boudin ground
-			round
-			<a
-				href="story-details.html"
-				class="ux-text-story-details-link ux-handler-moreclickable"
-				id="morelink"
-				>read more...</a
-			>
 			<script>
-				window.UXCapture.mark('ux-text-story-details-link');
+				// delaying this loop a tiny bit to show the difference
+				var y = 0;
+
+				for (var i = 0; i < 100000; i++) {
+					y += i;
+				}
 			</script>
-		</p>
-		<script>
-			window.UXCapture.mark('ux-text-story');
-		</script>
 
-		<p>
-			Suscipit anim. Fugit quaerat. Incididunt nesciunt. Cupidatat cillum sed. Laborum
-			totam and dolores sit. Commodi eos yet laboris. Dolorem cillum, excepteur yet
-			incididunt velit numquam. Ipsam error. Ratione consequuntur for magni ratione
-			and incididunt sit. Esse inventore yet nostrud so nesciunt, eius. Ratione
-			molestiae, autem, and dicta. Nostrud laboris labore, so nulla illum. Dolor totam
-			inventore iure yet omnis ipsam incidunt. Eiusmod beatae or ipsam, dolore.
-			Doloremque exercitationem. Error. Error modi. Ipsam ipsum or labore or ab
-			aspernatur. Aliquip. Laudantium voluptas eaque for eius, yet laboris sed so
-			dicta. Suscipit natus for eum veniam totam, for anim so fugiat. Suscipit
-			explicabo and cillum or rem explicabo. Sint vel eiusmod labore, or dolor so
-			nostrud for quae.
-		</p>
-		<p>
-			Aliquid velit but odit error. Aute cupidatat or beatae. Voluptas in
-			consequuntur. Incidunt vel, and consectetur. Numquam ipsa and est or dolorem so
-			amet. Aliqua ea molestiae labore for eiusmod eu commodo. Est nequeporro so
-			fugiat laborum laboriosam and nequeporro. Eu id yet irure so numquam yet
-			exercitation. Fugit fugiat dicta for aliquip, and iure. Vel consequatur modi. Ut
-			adipisicing yet nisi suscipit aute. Consequat esse laudantium. Amet cillum nisi
-			so ipsam ad minima but dolore. Aperiam adipisci eum quo do. Sed ex and nisi quo
-			quae quo for explicabo. Proident nesciunt for aliquid ratione. Occaecat
-			consequat for enim quia eos quis, tempor. Lorem perspiciatis. Dolore eius
-			consequatur error but minim. Pariatur cillum, ipsum explicabo but nemo. Aliquid
-			molestiae so aliqua. Omnis commodo. Voluptas. Error proident, but lorem aperiam.
-			Magnam quia laborum.
-		</p>
-		<p>
-			Lorem non. Aperiam exercitationem omnis. Consequatur rem labore architecto. Ad
-			molestiae explicabo but nemo for doloremque. Aliquip dolor, yet velitesse so
-			omnis vitae aspernatur. Modi. Aliqua.
-		</p>
+			<p class="ux-text-story">
+				Bacon ipsum dolor amet jowl swine brisket, drumstick pig chicken meatball ham
+				hock ham salami andouille hamburger. Ribeye alcatra porchetta flank. Venison
+				chicken meatloaf landjaeger. Porchetta burgdoggen ham hock, pork belly beef
+				ribs chicken meatloaf jowl strip steak t-bone. Pork chop turducken drumstick
+				kevin leberkas jowl chicken prosciutto salami meatloaf, tri-tip doner boudin
+				ground round
+				<a
+					href="story-details.html"
+					class="ux-text-story-details-link ux-handler-moreclickable"
+					id="morelink"
+					>read more...</a
+				>
+				<script>
+					window.UXCapture.mark('ux-text-story-details-link');
+				</script>
+			</p>
+			<script>
+				window.UXCapture.mark('ux-text-story');
+			</script>
 
-		<a href="page2.html" class="ux-text-page2">Page 2 &gt; &gt;</a>
-		<script>
-			window.UXCapture.mark('ux-text-page2');
-		</script>
+			<p>
+				Lorem non. Aperiam exercitationem omnis. Consequatur rem labore architecto. Ad
+				molestiae explicabo but nemo for doloremque. Aliquip dolor, yet velitesse so
+				omnis vitae aspernatur. Modi. Aliqua.
+			</p>
+
+			<a href="page2.html" class="ux-text-page2">Page 2 &gt; &gt;</a>
+			<script>
+				window.UXCapture.mark('ux-text-page2');
+			</script>
+		</div>
 
 		<script>
 			// emulating a long-running JS event attachment, e.g. React re-hydration
@@ -162,6 +137,49 @@
 
 				window.UXCapture.mark('ux-handler-moreclickable');
 			}, 300);
+
+			// mini-SPA
+			document.querySelector('a[href="page2.html"]').addEventListener('click', e => {
+				e.preventDefault();
+
+				// triggers initial mark
+				UXCapture.startTransition();
+
+				document.getElementById('content').innerHTML =
+					'<i>... loading page 2 ...</i>';
+
+				setTimeout(() => {
+					// sets new view expectations
+					UXCapture.startView([
+						{
+							name: 'ux-destination-verified',
+							elements: [
+								{
+									marks: ['ux-text-title'],
+									// CSS selector, same as () => document.querySelectorAll('h1')
+									elementSelector: 'h1',
+								},
+							],
+						},
+						{
+							name: 'ux-primary-content-displayed',
+							elements: [
+								{
+									marks: ['ux-text-page2-content'],
+									elementSelector: '#page2content',
+								},
+							],
+						},
+					]);
+
+					setTimeout(() => {
+						document.getElementById('content').innerHTML =
+							'<p id="page2content">SPA transition to page 2 successful</p>';
+
+						UXCapture.mark('ux-text-page2-content');
+					}, 900); // 1s delay between startTransition() and Primary Content Available
+				}, 100); // 100ms delay between startTransition() and startView();
+			});
 		</script>
 	</body>
 </html>

--- a/examples/selectors-universal.html
+++ b/examples/selectors-universal.html
@@ -118,89 +118,67 @@
 			window.UXCapture.mark('ux-text-title');
 		</script>
 
-		<p class="ux-capture-intro">
-			<img
-				class="kitten"
-				src="kitten.jpg"
-				style="float: left; margin: 0 1em 1em 0"
-				width="30%"
-				onload="window.UXCapture.mark('ux-image-onload-kitten')"
-			/>
+		<div id="content">
+			<p class="ux-capture-intro">
+				<img
+					class="kitten"
+					src="kitten.jpg"
+					style="float: left; margin: 0 1em 1em 0"
+					width="30%"
+					onload="window.UXCapture.mark('ux-image-onload-kitten')"
+				/>
+				<script>
+					window.UXCapture.mark('ux-image-inline-kitten');
+				</script>
+				Decide to want nothing to do with my owner today. When in doubt, wash being
+				gorgeous with belly side up sweet beast, but poop in the plant pot but munch
+				on tasty moths. Brown cats with pink ears. Caticus cuteicus when in doubt,
+				wash stare at ceiling, and scream at teh bath, lies down but cough hairball on
+				conveniently placed pants claw your carpet in places everyone can see - why
+				hide my amazing artistic clawing skills?. Meow in empty rooms.
+			</p>
 			<script>
-				window.UXCapture.mark('ux-image-inline-kitten');
+				window.UXCapture.mark('ux-text-intro');
 			</script>
-			Decide to want nothing to do with my owner today. When in doubt, wash being
-			gorgeous with belly side up sweet beast, but poop in the plant pot but munch on
-			tasty moths. Brown cats with pink ears. Caticus cuteicus when in doubt, wash
-			stare at ceiling, and scream at teh bath, lies down but cough hairball on
-			conveniently placed pants claw your carpet in places everyone can see - why hide
-			my amazing artistic clawing skills?. Meow in empty rooms.
-		</p>
-		<script>
-			window.UXCapture.mark('ux-text-intro');
-		</script>
 
-		<script>
-			// delaying this loop a tiny bit to show the difference
-			var y = 0;
-
-			for (var i = 0; i < 100000; i++) {
-				y += i;
-			}
-		</script>
-
-		<p class="ux-capture-story">
-			Bacon ipsum dolor amet jowl swine brisket, drumstick pig chicken meatball ham
-			hock ham salami andouille hamburger. Ribeye alcatra porchetta flank. Venison
-			chicken meatloaf landjaeger. Porchetta burgdoggen ham hock, pork belly beef ribs
-			chicken meatloaf jowl strip steak t-bone. Pork chop turducken drumstick kevin
-			leberkas jowl chicken prosciutto salami meatloaf, tri-tip doner boudin ground
-			round <a href="story-details.html" class="ux-capture-details">read more...</a>
 			<script>
-				window.UXCapture.mark('ux-text-story-details-link');
+				// delaying this loop a tiny bit to show the difference
+				var y = 0;
+
+				for (var i = 0; i < 100000; i++) {
+					y += i;
+				}
 			</script>
-		</p>
-		<script>
-			window.UXCapture.mark('ux-text-story');
-		</script>
 
-		<p>
-			Suscipit anim. Fugit quaerat. Incididunt nesciunt. Cupidatat cillum sed. Laborum
-			totam and dolores sit. Commodi eos yet laboris. Dolorem cillum, excepteur yet
-			incididunt velit numquam. Ipsam error. Ratione consequuntur for magni ratione
-			and incididunt sit. Esse inventore yet nostrud so nesciunt, eius. Ratione
-			molestiae, autem, and dicta. Nostrud laboris labore, so nulla illum. Dolor totam
-			inventore iure yet omnis ipsam incidunt. Eiusmod beatae or ipsam, dolore.
-			Doloremque exercitationem. Error. Error modi. Ipsam ipsum or labore or ab
-			aspernatur. Aliquip. Laudantium voluptas eaque for eius, yet laboris sed so
-			dicta. Suscipit natus for eum veniam totam, for anim so fugiat. Suscipit
-			explicabo and cillum or rem explicabo. Sint vel eiusmod labore, or dolor so
-			nostrud for quae.
-		</p>
-		<p>
-			Aliquid velit but odit error. Aute cupidatat or beatae. Voluptas in
-			consequuntur. Incidunt vel, and consectetur. Numquam ipsa and est or dolorem so
-			amet. Aliqua ea molestiae labore for eiusmod eu commodo. Est nequeporro so
-			fugiat laborum laboriosam and nequeporro. Eu id yet irure so numquam yet
-			exercitation. Fugit fugiat dicta for aliquip, and iure. Vel consequatur modi. Ut
-			adipisicing yet nisi suscipit aute. Consequat esse laudantium. Amet cillum nisi
-			so ipsam ad minima but dolore. Aperiam adipisci eum quo do. Sed ex and nisi quo
-			quae quo for explicabo. Proident nesciunt for aliquid ratione. Occaecat
-			consequat for enim quia eos quis, tempor. Lorem perspiciatis. Dolore eius
-			consequatur error but minim. Pariatur cillum, ipsum explicabo but nemo. Aliquid
-			molestiae so aliqua. Omnis commodo. Voluptas. Error proident, but lorem aperiam.
-			Magnam quia laborum.
-		</p>
-		<p>
-			Lorem non. Aperiam exercitationem omnis. Consequatur rem labore architecto. Ad
-			molestiae explicabo but nemo for doloremque. Aliquip dolor, yet velitesse so
-			omnis vitae aspernatur. Modi. Aliqua.
-		</p>
+			<p class="ux-capture-story">
+				Bacon ipsum dolor amet jowl swine brisket, drumstick pig chicken meatball ham
+				hock ham salami andouille hamburger. Ribeye alcatra porchetta flank. Venison
+				chicken meatloaf landjaeger. Porchetta burgdoggen ham hock, pork belly beef
+				ribs chicken meatloaf jowl strip steak t-bone. Pork chop turducken drumstick
+				kevin leberkas jowl chicken prosciutto salami meatloaf, tri-tip doner boudin
+				ground round
+				<a href="story-details.html" id="morelink" class="ux-capture-details"
+					>read more...</a
+				>
+				<script>
+					window.UXCapture.mark('ux-text-story-details-link');
+				</script>
+			</p>
+			<script>
+				window.UXCapture.mark('ux-text-story');
+			</script>
 
-		<a href="page2.html" class="ux-capture-page2-link">Page 2 &gt; &gt;</a>
-		<script>
-			window.UXCapture.mark('ux-text-page2');
-		</script>
+			<p>
+				Lorem non. Aperiam exercitationem omnis. Consequatur rem labore architecto. Ad
+				molestiae explicabo but nemo for doloremque. Aliquip dolor, yet velitesse so
+				omnis vitae aspernatur. Modi. Aliqua.
+			</p>
+
+			<a href="page2.html" class="ux-capture-page2-link">Page 2 &gt; &gt;</a>
+			<script>
+				window.UXCapture.mark('ux-text-page2');
+			</script>
+		</div>
 
 		<script>
 			// emulating a long-running JS event attachment, e.g. React re-hydration
@@ -213,6 +191,49 @@
 
 				window.UXCapture.mark('ux-handler-moreclickable');
 			}, 300);
+
+			// mini-SPA
+			document.querySelector('a[href="page2.html"]').addEventListener('click', e => {
+				e.preventDefault();
+
+				// triggers initial mark
+				UXCapture.startTransition();
+
+				document.getElementById('content').innerHTML =
+					'<i>... loading page 2 ...</i>';
+
+				setTimeout(() => {
+					// sets new view expectations
+					UXCapture.startView([
+						{
+							name: 'ux-destination-verified',
+							elements: [
+								{
+									marks: ['ux-text-title'],
+									// CSS selector, same as () => document.querySelectorAll('h1')
+									elementSelector: 'h1',
+								},
+							],
+						},
+						{
+							name: 'ux-primary-content-displayed',
+							elements: [
+								{
+									marks: ['ux-text-page2-content'],
+									elementSelector: '#page2content',
+								},
+							],
+						},
+					]);
+
+					setTimeout(() => {
+						document.getElementById('content').innerHTML =
+							'<p id="page2content">SPA transition to page 2 successful</p>';
+
+						UXCapture.mark('ux-text-page2-content');
+					}, 900); // 1s delay between startTransition() and Primary Content Available
+				}, 100); // 100ms delay between startTransition() and startView();
+			});
 		</script>
 	</body>
 </html>

--- a/examples/selectors-universal.html
+++ b/examples/selectors-universal.html
@@ -110,6 +110,7 @@
 				},
 			]);
 		</script>
+		<script src="micro_spa.js" async></script>
 	</head>
 
 	<body>
@@ -179,61 +180,5 @@
 				window.UXCapture.mark('ux-text-page2');
 			</script>
 		</div>
-
-		<script>
-			// emulating a long-running JS event attachment, e.g. React re-hydration
-			setTimeout(() => {
-				document.getElementById('morelink').addEventListener('click', function(e) {
-					e.preventDefault();
-
-					alert('More kittens there');
-				});
-
-				window.UXCapture.mark('ux-handler-moreclickable');
-			}, 300);
-
-			// mini-SPA
-			document.querySelector('a[href="page2.html"]').addEventListener('click', e => {
-				e.preventDefault();
-
-				// triggers initial mark
-				UXCapture.startTransition();
-
-				document.getElementById('content').innerHTML =
-					'<i>... loading page 2 ...</i>';
-
-				setTimeout(() => {
-					// sets new view expectations
-					UXCapture.startView([
-						{
-							name: 'ux-destination-verified',
-							elements: [
-								{
-									marks: ['ux-text-title'],
-									// CSS selector, same as () => document.querySelectorAll('h1')
-									elementSelector: 'h1',
-								},
-							],
-						},
-						{
-							name: 'ux-primary-content-displayed',
-							elements: [
-								{
-									marks: ['ux-text-page2-content'],
-									elementSelector: '#page2content',
-								},
-							],
-						},
-					]);
-
-					setTimeout(() => {
-						document.getElementById('content').innerHTML =
-							'<p id="page2content">SPA transition to page 2 successful</p>';
-
-						UXCapture.mark('ux-text-page2-content');
-					}, 900); // 1s delay between startTransition() and Primary Content Available
-				}, 100); // 100ms delay between startTransition() and startView();
-			});
-		</script>
 	</body>
 </html>

--- a/examples/selectors-universal.html
+++ b/examples/selectors-universal.html
@@ -1,0 +1,218 @@
+<html>
+	<head>
+		<title>Sample Page | UX capture</title>
+
+		<!-- don't do this in production, but inline it instead -->
+		<script src="../lib/ux-capture.min.js"></script>
+
+		<script>
+			// sample custom reporter function for collected measures
+			const customMeasureRecordingFunction = name => {
+				// there can be multiple entries with the same name, get the latest
+				const measure = performance
+					.getEntriesByType('measure')
+					.filter(entry => entry.name === name)
+					.pop();
+
+				if (typeof measure.duration !== 'undefined') {
+					// in real world you might be sending this to your custom monitoring solution
+					// (because it does not support W3C UserTiming API natively)
+					console.log('Measure', name, ':', measure.duration);
+				}
+			};
+
+			// universal selector used for all zones
+			// this can encorporate established site-wide pattern like using classes to denote elements
+			const universalElementSelector = element =>
+				document.querySelectorAll(`.ux-capture-${element.name}`);
+
+			window.UXCapture.create({
+				onMeasure: customMeasureRecordingFunction,
+				elementSelector: universalElementSelector,
+			});
+
+			/**
+			 * Array of zone objects groupping elements together
+			 *
+			 * window.UXCapture.startView([
+			 * {
+			 *  name: "ux-destination-verified",
+			 *  elements: ...
+			 * }
+			 * ]);
+			 *
+			 * Using elements array with elementSelector and optional expectedElements properties
+			 * will allow you to automatically detect already rendered elements and zones during startView() call
+			 * in interactive views.
+			 *
+			 * Each element is marked using UserTiming and selectors
+			 * elements: [{
+			 *  // [<string>] - names of marks to expect for this element
+			 *  marks: ["ux-image-logo-onload", "ux-image-logo-inline"],
+			 *
+			 *  // <string|function> - string is an input to document.querySelectorAll()
+			 *  //                     or function that returns a collection of DOM nodes.
+			 *  // Used to detect if elements are already on the page on SPA transition
+			 *  // and for highlighting during debugging
+			 *  elementSelector: "h1",
+			 *
+			 *  // <number|function> - number is used to compare to return of elementSelector
+			 *  //                     or function that returns a boolean indicating if element
+			 *  //                     is already displayed and functional
+			 *  // default: 1
+			 *  expectedElements: 2
+			 * }]
+			 */
+			window.UXCapture.startView([
+				{
+					name: 'ux-destination-verified',
+					elements: [
+						{
+							name: 'title',
+							marks: ['ux-text-title'],
+						},
+					],
+				},
+				{
+					name: 'ux-primary-content-displayed',
+					elements: [
+						{
+							name: 'intro',
+							marks: ['ux-text-intro'],
+						},
+						{
+							name: 'story',
+							marks: ['ux-text-story'],
+						},
+						{
+							name: 'kitten',
+							marks: ['ux-image-onload-kitten', 'ux-image-inline-kitten'],
+						},
+					],
+				},
+				{
+					name: 'ux-primary-action-available',
+					elements: [
+						{
+							name: 'details',
+							marks: ['ux-text-story-details-link', 'ux-handler-moreclickable'],
+						},
+					],
+				},
+				{
+					name: 'ux-secondary-content-displayed',
+					elements: [
+						{
+							name: 'page2-link',
+							marks: ['ux-text-page2'],
+						},
+					],
+				},
+			]);
+		</script>
+	</head>
+
+	<body>
+		<h1 class="ux-capture-title">UX Capture library sample page</h1>
+		<script>
+			window.UXCapture.mark('ux-text-title');
+		</script>
+
+		<p class="ux-capture-intro">
+			<img
+				class="kitten"
+				src="kitten.jpg"
+				style="float: left; margin: 0 1em 1em 0"
+				width="30%"
+				onload="window.UXCapture.mark('ux-image-onload-kitten')"
+			/>
+			<script>
+				window.UXCapture.mark('ux-image-inline-kitten');
+			</script>
+			Decide to want nothing to do with my owner today. When in doubt, wash being
+			gorgeous with belly side up sweet beast, but poop in the plant pot but munch on
+			tasty moths. Brown cats with pink ears. Caticus cuteicus when in doubt, wash
+			stare at ceiling, and scream at teh bath, lies down but cough hairball on
+			conveniently placed pants claw your carpet in places everyone can see - why hide
+			my amazing artistic clawing skills?. Meow in empty rooms.
+		</p>
+		<script>
+			window.UXCapture.mark('ux-text-intro');
+		</script>
+
+		<script>
+			// delaying this loop a tiny bit to show the difference
+			var y = 0;
+
+			for (var i = 0; i < 100000; i++) {
+				y += i;
+			}
+		</script>
+
+		<p class="ux-capture-story">
+			Bacon ipsum dolor amet jowl swine brisket, drumstick pig chicken meatball ham
+			hock ham salami andouille hamburger. Ribeye alcatra porchetta flank. Venison
+			chicken meatloaf landjaeger. Porchetta burgdoggen ham hock, pork belly beef ribs
+			chicken meatloaf jowl strip steak t-bone. Pork chop turducken drumstick kevin
+			leberkas jowl chicken prosciutto salami meatloaf, tri-tip doner boudin ground
+			round <a href="story-details.html" class="ux-capture-details">read more...</a>
+			<script>
+				window.UXCapture.mark('ux-text-story-details-link');
+			</script>
+		</p>
+		<script>
+			window.UXCapture.mark('ux-text-story');
+		</script>
+
+		<p>
+			Suscipit anim. Fugit quaerat. Incididunt nesciunt. Cupidatat cillum sed. Laborum
+			totam and dolores sit. Commodi eos yet laboris. Dolorem cillum, excepteur yet
+			incididunt velit numquam. Ipsam error. Ratione consequuntur for magni ratione
+			and incididunt sit. Esse inventore yet nostrud so nesciunt, eius. Ratione
+			molestiae, autem, and dicta. Nostrud laboris labore, so nulla illum. Dolor totam
+			inventore iure yet omnis ipsam incidunt. Eiusmod beatae or ipsam, dolore.
+			Doloremque exercitationem. Error. Error modi. Ipsam ipsum or labore or ab
+			aspernatur. Aliquip. Laudantium voluptas eaque for eius, yet laboris sed so
+			dicta. Suscipit natus for eum veniam totam, for anim so fugiat. Suscipit
+			explicabo and cillum or rem explicabo. Sint vel eiusmod labore, or dolor so
+			nostrud for quae.
+		</p>
+		<p>
+			Aliquid velit but odit error. Aute cupidatat or beatae. Voluptas in
+			consequuntur. Incidunt vel, and consectetur. Numquam ipsa and est or dolorem so
+			amet. Aliqua ea molestiae labore for eiusmod eu commodo. Est nequeporro so
+			fugiat laborum laboriosam and nequeporro. Eu id yet irure so numquam yet
+			exercitation. Fugit fugiat dicta for aliquip, and iure. Vel consequatur modi. Ut
+			adipisicing yet nisi suscipit aute. Consequat esse laudantium. Amet cillum nisi
+			so ipsam ad minima but dolore. Aperiam adipisci eum quo do. Sed ex and nisi quo
+			quae quo for explicabo. Proident nesciunt for aliquid ratione. Occaecat
+			consequat for enim quia eos quis, tempor. Lorem perspiciatis. Dolore eius
+			consequatur error but minim. Pariatur cillum, ipsum explicabo but nemo. Aliquid
+			molestiae so aliqua. Omnis commodo. Voluptas. Error proident, but lorem aperiam.
+			Magnam quia laborum.
+		</p>
+		<p>
+			Lorem non. Aperiam exercitationem omnis. Consequatur rem labore architecto. Ad
+			molestiae explicabo but nemo for doloremque. Aliquip dolor, yet velitesse so
+			omnis vitae aspernatur. Modi. Aliqua.
+		</p>
+
+		<a href="page2.html" class="ux-capture-page2-link">Page 2 &gt; &gt;</a>
+		<script>
+			window.UXCapture.mark('ux-text-page2');
+		</script>
+
+		<script>
+			// emulating a long-running JS event attachment, e.g. React re-hydration
+			setTimeout(() => {
+				document.getElementById('morelink').addEventListener('click', function(e) {
+					e.preventDefault();
+
+					alert('More kittens there');
+				});
+
+				window.UXCapture.mark('ux-handler-moreclickable');
+			}, 300);
+		</script>
+	</body>
+</html>

--- a/examples/selectors.html
+++ b/examples/selectors.html
@@ -116,6 +116,7 @@
 				},
 			]);
 		</script>
+		<script src="micro_spa.js" async></script>
 	</head>
 
 	<body>
@@ -182,62 +183,5 @@
 				UXCapture.mark('ux-text-page2');
 			</script>
 		</div>
-
-		<script>
-			// emulating a long-running JS event attachment, e.g. React re-hydration
-			setTimeout(() => {
-				// this handler actually triggers second view
-				document.getElementById('morelink').addEventListener('click', e => {
-					e.preventDefault();
-
-					alert('More kittens there');
-				});
-
-				UXCapture.mark('ux-handler-moreclickable');
-			}, 300);
-
-			// mini-SPA
-			document.querySelector('a[href="page2.html"]').addEventListener('click', e => {
-				e.preventDefault();
-
-				// triggers initial mark
-				UXCapture.startTransition();
-
-				document.getElementById('content').innerHTML =
-					'<i>... loading page 2 ...</i>';
-
-				setTimeout(() => {
-					// sets new view expectations
-					UXCapture.startView([
-						{
-							name: 'ux-destination-verified',
-							elements: [
-								{
-									marks: ['ux-text-title'],
-									// CSS selector, same as () => document.querySelectorAll('h1')
-									elementSelector: 'h1',
-								},
-							],
-						},
-						{
-							name: 'ux-primary-content-displayed',
-							elements: [
-								{
-									marks: ['ux-text-page2-content'],
-									elementSelector: '#page2content',
-								},
-							],
-						},
-					]);
-
-					setTimeout(() => {
-						document.getElementById('content').innerHTML =
-							'<p id="page2content">SPA transition to page 2 successful</p>';
-
-						UXCapture.mark('ux-text-page2-content');
-					}, 900); // 1s delay between startTransition() and Primary Content Available
-				}, 100); // 100ms delay between startTransition() and startView();
-			});
-		</script>
 	</body>
 </html>

--- a/examples/selectors.html
+++ b/examples/selectors.html
@@ -1,0 +1,224 @@
+<html>
+	<head>
+		<title>Sample Page | UX capture</title>
+
+		<!-- don't do this in production, but inline it instead -->
+		<script src="../lib/ux-capture.min.js"></script>
+
+		<script>
+			// sample custom reporter function for collected measures
+			const customMeasureRecordingFunction = name => {
+				// there can be multiple entries with the same name, get the latest
+				const measure = performance
+					.getEntriesByType('measure')
+					.filter(entry => entry.name === name)
+					.pop();
+
+				if (typeof measure.duration !== 'undefined') {
+					// in real world you might be sending this to your custom monitoring solution
+					// (because it does not support W3C UserTiming API natively)
+					console.log('Measure', name, ':', measure.duration);
+				}
+			};
+
+			window.UXCapture.create({
+				onMeasure: customMeasureRecordingFunction,
+			});
+
+			/**
+			 * Array of zone objects groupping elements together
+			 *
+			 * window.UXCapture.startView([
+			 * {
+			 *  name: "ux-destination-verified",
+			 *  elements: ...
+			 * }
+			 * ]);
+			 *
+			 * Using elements array with elementSelector and optional expectedElements properties
+			 * will allow you to automatically detect already rendered elements and zones during startView() call
+			 * in interactive views.
+			 *
+			 * Each element is marked using UserTiming and selectors
+			 * elements: [{
+			 *  // [<string>] - names of marks to expect for this element
+			 *  marks: ["ux-image-logo-onload", "ux-image-logo-inline"],
+			 *
+			 *  // <string|function> - string is an input to document.querySelectorAll()
+			 *  //                     or function that returns a collection of DOM nodes.
+			 *  // Used to detect if elements are already on the page on SPA transition
+			 *  // and for highlighting during debugging
+			 *  elementSelector: "h1",
+			 *
+			 *  // <number|function> - number is used to compare to return of elementSelector
+			 *  //                     or function that returns a boolean indicating if element
+			 *  //                     is already displayed and functional
+			 *  // default: 1
+			 *  expectedElements: 2
+			 * }]
+			 */
+			window.UXCapture.startView([
+				{
+					name: 'ux-destination-verified',
+					elements: [
+						{
+							marks: ['ux-text-title'],
+							// CSS selector, same as () => document.querySelectorAll('h1')
+							elementSelector: 'h1',
+						},
+					],
+				},
+				{
+					name: 'ux-primary-content-displayed',
+					elements: [
+						{
+							marks: ['ux-text-intro'],
+							elementSelector: '#intro',
+						},
+						{
+							marks: ['ux-text-story'],
+							elementSelector: '#story',
+						},
+						{
+							marks: ['ux-image-onload-kitten', 'ux-image-inline-kitten'],
+							elementSelector: 'img.cute',
+						},
+					],
+				},
+				{
+					name: 'ux-primary-action-available',
+					elements: [
+						{
+							marks: ['ux-text-story-details-link', 'ux-handler-moreclickable'],
+							elementSelector: 'morelink',
+							// number of elements to expect from elementSelectort
+							// or a function returning boolean
+							expectedElements: () => {
+								document.querySelectorAll('#morelink').length > 0;
+							},
+						},
+					],
+				},
+				{
+					name: 'ux-secondary-content-displayed',
+					elements: [
+						{
+							marks: ['ux-text-page2'],
+							// function-based selector
+							elementSelector: () => {
+								document
+									.querySelectorAll('a')
+									.filter(element => element.href === 'page2.html');
+							},
+							expectedElements: 1,
+						},
+					],
+				},
+			]);
+		</script>
+	</head>
+
+	<body>
+		<h1>UX Capture library sample page</h1>
+		<script>
+			window.UXCapture.mark('ux-text-title');
+		</script>
+
+		<p id="intro">
+			<img
+				class="cute"
+				src="kitten.jpg"
+				style="float: left; margin: 0 1em 1em 0"
+				width="30%"
+				onload="window.UXCapture.mark('ux-image-onload-kitten')"
+			/>
+			<script>
+				window.UXCapture.mark('ux-image-inline-kitten');
+			</script>
+			Decide to want nothing to do with my owner today. When in doubt, wash being
+			gorgeous with belly side up sweet beast, but poop in the plant pot but munch on
+			tasty moths. Brown cats with pink ears. Caticus cuteicus when in doubt, wash
+			stare at ceiling, and scream at teh bath, lies down but cough hairball on
+			conveniently placed pants claw your carpet in places everyone can see - why hide
+			my amazing artistic clawing skills?. Meow in empty rooms.
+		</p>
+		<script>
+			window.UXCapture.mark('ux-text-intro');
+		</script>
+
+		<script>
+			// delaying this loop a tiny bit to show the difference
+			var y = 0;
+
+			for (var i = 0; i < 100000; i++) {
+				y += i;
+			}
+		</script>
+
+		<p id="story">
+			Bacon ipsum dolor amet jowl swine brisket, drumstick pig chicken meatball ham
+			hock ham salami andouille hamburger. Ribeye alcatra porchetta flank. Venison
+			chicken meatloaf landjaeger. Porchetta burgdoggen ham hock, pork belly beef ribs
+			chicken meatloaf jowl strip steak t-bone. Pork chop turducken drumstick kevin
+			leberkas jowl chicken prosciutto salami meatloaf, tri-tip doner boudin ground
+			round <a href="story-details.html" id="morelink">read more...</a>
+			<script>
+				window.UXCapture.mark('ux-text-story-details-link');
+			</script>
+		</p>
+		<script>
+			window.UXCapture.mark('ux-text-story');
+		</script>
+
+		<p>
+			Suscipit anim. Fugit quaerat. Incididunt nesciunt. Cupidatat cillum sed. Laborum
+			totam and dolores sit. Commodi eos yet laboris. Dolorem cillum, excepteur yet
+			incididunt velit numquam. Ipsam error. Ratione consequuntur for magni ratione
+			and incididunt sit. Esse inventore yet nostrud so nesciunt, eius. Ratione
+			molestiae, autem, and dicta. Nostrud laboris labore, so nulla illum. Dolor totam
+			inventore iure yet omnis ipsam incidunt. Eiusmod beatae or ipsam, dolore.
+			Doloremque exercitationem. Error. Error modi. Ipsam ipsum or labore or ab
+			aspernatur. Aliquip. Laudantium voluptas eaque for eius, yet laboris sed so
+			dicta. Suscipit natus for eum veniam totam, for anim so fugiat. Suscipit
+			explicabo and cillum or rem explicabo. Sint vel eiusmod labore, or dolor so
+			nostrud for quae.
+		</p>
+		<p>
+			Aliquid velit but odit error. Aute cupidatat or beatae. Voluptas in
+			consequuntur. Incidunt vel, and consectetur. Numquam ipsa and est or dolorem so
+			amet. Aliqua ea molestiae labore for eiusmod eu commodo. Est nequeporro so
+			fugiat laborum laboriosam and nequeporro. Eu id yet irure so numquam yet
+			exercitation. Fugit fugiat dicta for aliquip, and iure. Vel consequatur modi. Ut
+			adipisicing yet nisi suscipit aute. Consequat esse laudantium. Amet cillum nisi
+			so ipsam ad minima but dolore. Aperiam adipisci eum quo do. Sed ex and nisi quo
+			quae quo for explicabo. Proident nesciunt for aliquid ratione. Occaecat
+			consequat for enim quia eos quis, tempor. Lorem perspiciatis. Dolore eius
+			consequatur error but minim. Pariatur cillum, ipsum explicabo but nemo. Aliquid
+			molestiae so aliqua. Omnis commodo. Voluptas. Error proident, but lorem aperiam.
+			Magnam quia laborum.
+		</p>
+		<p>
+			Lorem non. Aperiam exercitationem omnis. Consequatur rem labore architecto. Ad
+			molestiae explicabo but nemo for doloremque. Aliquip dolor, yet velitesse so
+			omnis vitae aspernatur. Modi. Aliqua.
+		</p>
+
+		<a href="page2.html">Page 2 &gt; &gt;</a>
+		<script>
+			window.UXCapture.mark('ux-text-page2');
+		</script>
+
+		<script>
+			// emulating a long-running JS event attachment, e.g. React re-hydration
+			setTimeout(() => {
+				document.getElementById('morelink').addEventListener('click', function(e) {
+					e.preventDefault();
+
+					alert('More kittens there');
+				});
+
+				window.UXCapture.mark('ux-handler-moreclickable');
+			}, 300);
+		</script>
+	</body>
+</html>

--- a/examples/selectors.html
+++ b/examples/selectors.html
@@ -21,14 +21,14 @@
 				}
 			};
 
-			window.UXCapture.create({
+			UXCapture.create({
 				onMeasure: customMeasureRecordingFunction,
 			});
 
 			/**
 			 * Array of zone objects groupping elements together
 			 *
-			 * window.UXCapture.startView([
+			 * UXCapture.startView([
 			 * {
 			 *  name: "ux-destination-verified",
 			 *  elements: ...
@@ -57,7 +57,7 @@
 			 *  expectedElements: 2
 			 * }]
 			 */
-			window.UXCapture.startView([
+			UXCapture.startView([
 				{
 					name: 'ux-destination-verified',
 					elements: [
@@ -106,9 +106,9 @@
 							marks: ['ux-text-page2'],
 							// function-based selector
 							elementSelector: () => {
-								document
-									.querySelectorAll('a')
-									.filter(element => element.href === 'page2.html');
+								[...document.querySelectorAll('a')].filter(
+									element => element.href === 'page2.html'
+								);
 							},
 							expectedElements: 1,
 						},
@@ -121,104 +121,123 @@
 	<body>
 		<h1>UX Capture library sample page</h1>
 		<script>
-			window.UXCapture.mark('ux-text-title');
+			UXCapture.mark('ux-text-title');
 		</script>
 
-		<p id="intro">
-			<img
-				class="cute"
-				src="kitten.jpg"
-				style="float: left; margin: 0 1em 1em 0"
-				width="30%"
-				onload="window.UXCapture.mark('ux-image-onload-kitten')"
-			/>
+		<div id="content">
+			<p id="intro">
+				<img
+					class="cute"
+					src="kitten.jpg"
+					style="float: left; margin: 0 1em 1em 0"
+					width="30%"
+					onload="UXCapture.mark('ux-image-onload-kitten')"
+				/>
+				<script>
+					UXCapture.mark('ux-image-inline-kitten');
+				</script>
+				Decide to want nothing to do with my owner today. When in doubt, wash being
+				gorgeous with belly side up sweet beast, but poop in the plant pot but munch
+				on tasty moths. Brown cats with pink ears. Caticus cuteicus when in doubt,
+				wash stare at ceiling, and scream at teh bath, lies down but cough hairball on
+				conveniently placed pants claw your carpet in places everyone can see - why
+				hide my amazing artistic clawing skills?. Meow in empty rooms.
+			</p>
 			<script>
-				window.UXCapture.mark('ux-image-inline-kitten');
+				UXCapture.mark('ux-text-intro');
 			</script>
-			Decide to want nothing to do with my owner today. When in doubt, wash being
-			gorgeous with belly side up sweet beast, but poop in the plant pot but munch on
-			tasty moths. Brown cats with pink ears. Caticus cuteicus when in doubt, wash
-			stare at ceiling, and scream at teh bath, lies down but cough hairball on
-			conveniently placed pants claw your carpet in places everyone can see - why hide
-			my amazing artistic clawing skills?. Meow in empty rooms.
-		</p>
-		<script>
-			window.UXCapture.mark('ux-text-intro');
-		</script>
 
-		<script>
-			// delaying this loop a tiny bit to show the difference
-			var y = 0;
-
-			for (var i = 0; i < 100000; i++) {
-				y += i;
-			}
-		</script>
-
-		<p id="story">
-			Bacon ipsum dolor amet jowl swine brisket, drumstick pig chicken meatball ham
-			hock ham salami andouille hamburger. Ribeye alcatra porchetta flank. Venison
-			chicken meatloaf landjaeger. Porchetta burgdoggen ham hock, pork belly beef ribs
-			chicken meatloaf jowl strip steak t-bone. Pork chop turducken drumstick kevin
-			leberkas jowl chicken prosciutto salami meatloaf, tri-tip doner boudin ground
-			round <a href="story-details.html" id="morelink">read more...</a>
 			<script>
-				window.UXCapture.mark('ux-text-story-details-link');
+				// delaying this loop a tiny bit to show the difference
+				var y = 0;
+
+				for (var i = 0; i < 100000; i++) {
+					y += i;
+				}
 			</script>
-		</p>
-		<script>
-			window.UXCapture.mark('ux-text-story');
-		</script>
 
-		<p>
-			Suscipit anim. Fugit quaerat. Incididunt nesciunt. Cupidatat cillum sed. Laborum
-			totam and dolores sit. Commodi eos yet laboris. Dolorem cillum, excepteur yet
-			incididunt velit numquam. Ipsam error. Ratione consequuntur for magni ratione
-			and incididunt sit. Esse inventore yet nostrud so nesciunt, eius. Ratione
-			molestiae, autem, and dicta. Nostrud laboris labore, so nulla illum. Dolor totam
-			inventore iure yet omnis ipsam incidunt. Eiusmod beatae or ipsam, dolore.
-			Doloremque exercitationem. Error. Error modi. Ipsam ipsum or labore or ab
-			aspernatur. Aliquip. Laudantium voluptas eaque for eius, yet laboris sed so
-			dicta. Suscipit natus for eum veniam totam, for anim so fugiat. Suscipit
-			explicabo and cillum or rem explicabo. Sint vel eiusmod labore, or dolor so
-			nostrud for quae.
-		</p>
-		<p>
-			Aliquid velit but odit error. Aute cupidatat or beatae. Voluptas in
-			consequuntur. Incidunt vel, and consectetur. Numquam ipsa and est or dolorem so
-			amet. Aliqua ea molestiae labore for eiusmod eu commodo. Est nequeporro so
-			fugiat laborum laboriosam and nequeporro. Eu id yet irure so numquam yet
-			exercitation. Fugit fugiat dicta for aliquip, and iure. Vel consequatur modi. Ut
-			adipisicing yet nisi suscipit aute. Consequat esse laudantium. Amet cillum nisi
-			so ipsam ad minima but dolore. Aperiam adipisci eum quo do. Sed ex and nisi quo
-			quae quo for explicabo. Proident nesciunt for aliquid ratione. Occaecat
-			consequat for enim quia eos quis, tempor. Lorem perspiciatis. Dolore eius
-			consequatur error but minim. Pariatur cillum, ipsum explicabo but nemo. Aliquid
-			molestiae so aliqua. Omnis commodo. Voluptas. Error proident, but lorem aperiam.
-			Magnam quia laborum.
-		</p>
-		<p>
-			Lorem non. Aperiam exercitationem omnis. Consequatur rem labore architecto. Ad
-			molestiae explicabo but nemo for doloremque. Aliquip dolor, yet velitesse so
-			omnis vitae aspernatur. Modi. Aliqua.
-		</p>
+			<p id="story">
+				Bacon ipsum dolor amet jowl swine brisket, drumstick pig chicken meatball ham
+				hock ham salami andouille hamburger. Ribeye alcatra porchetta flank. Venison
+				chicken meatloaf landjaeger. Porchetta burgdoggen ham hock, pork belly beef
+				ribs chicken meatloaf jowl strip steak t-bone. Pork chop turducken drumstick
+				kevin leberkas jowl chicken prosciutto salami meatloaf, tri-tip doner boudin
+				ground round <a href="story-details.html" id="morelink">read more...</a>
+				<script>
+					UXCapture.mark('ux-text-story-details-link');
+				</script>
+			</p>
+			<script>
+				UXCapture.mark('ux-text-story');
+			</script>
 
-		<a href="page2.html">Page 2 &gt; &gt;</a>
-		<script>
-			window.UXCapture.mark('ux-text-page2');
-		</script>
+			<p>
+				Lorem non. Aperiam exercitationem omnis. Consequatur rem labore architecto. Ad
+				molestiae explicabo but nemo for doloremque. Aliquip dolor, yet velitesse so
+				omnis vitae aspernatur. Modi. Aliqua.
+			</p>
+
+			<a href="page2.html">Page 2 &gt; &gt;</a>
+			<script>
+				UXCapture.mark('ux-text-page2');
+			</script>
+		</div>
 
 		<script>
 			// emulating a long-running JS event attachment, e.g. React re-hydration
 			setTimeout(() => {
-				document.getElementById('morelink').addEventListener('click', function(e) {
+				// this handler actually triggers second view
+				document.getElementById('morelink').addEventListener('click', e => {
 					e.preventDefault();
 
 					alert('More kittens there');
 				});
 
-				window.UXCapture.mark('ux-handler-moreclickable');
+				UXCapture.mark('ux-handler-moreclickable');
 			}, 300);
+
+			// mini-SPA
+			document.querySelector('a[href="page2.html"]').addEventListener('click', e => {
+				e.preventDefault();
+
+				// triggers initial mark
+				UXCapture.startTransition();
+
+				document.getElementById('content').innerHTML =
+					'<i>... loading page 2 ...</i>';
+
+				setTimeout(() => {
+					// sets new view expectations
+					UXCapture.startView([
+						{
+							name: 'ux-destination-verified',
+							elements: [
+								{
+									marks: ['ux-text-title'],
+									// CSS selector, same as () => document.querySelectorAll('h1')
+									elementSelector: 'h1',
+								},
+							],
+						},
+						{
+							name: 'ux-primary-content-displayed',
+							elements: [
+								{
+									marks: ['ux-text-page2-content'],
+									elementSelector: '#page2content',
+								},
+							],
+						},
+					]);
+
+					setTimeout(() => {
+						document.getElementById('content').innerHTML =
+							'<p id="page2content">SPA transition to page 2 successful</p>';
+
+						UXCapture.mark('ux-text-page2-content');
+					}, 900); // 1s delay between startTransition() and Primary Content Available
+				}, 100); // 100ms delay between startTransition() and startView();
+			});
 		</script>
 	</body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ux-capture",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Browser instrumentation helper that makes it easier to capture UX speed metrics",
   "main": "src/ux-capture.js",
   "directories": {

--- a/src/ExpectedMark.js
+++ b/src/ExpectedMark.js
@@ -31,7 +31,7 @@ export default class ExpectedMark extends UXBase {
 		return _expectedMarks[name];
 	}
 
-	static clearExpectedMarks() {
+	static clearExpectedMarksMap() {
 		_expectedMarks = {};
 	}
 

--- a/src/UXCapture.js
+++ b/src/UXCapture.js
@@ -12,13 +12,15 @@ const NAVIGATION_START_MARK_NAME = 'navigationStart';
 /**
  * Used to mark start of interactive view
  */
-const INTERACTIVE_TRANSITION_START_MARK_NAME = 'transitionStart';
+export const INTERACTIVE_TRANSITION_START_MARK_NAME = 'transitionStart';
 
 export const VIEW_OVERRIDE_ERROR_MESSAGE =
 	'[UX Capture] Application should call UXCapture.startTransition() before starting new view';
 
 let _onMark;
 let _onMeasure;
+let _markSelector;
+let _elementSelector;
 let _view;
 let _startMarkName = NAVIGATION_START_MARK_NAME;
 
@@ -45,6 +47,8 @@ const UXCapture = {
 	create: config => {
 		_onMark = config.onMark || NOOP;
 		_onMeasure = config.onMeasure || NOOP;
+		_markSelector = config.markSelector;
+		_elementSelector = config.elementSelector;
 		_startMarkName = NAVIGATION_START_MARK_NAME;
 	},
 
@@ -61,6 +65,8 @@ const UXCapture = {
 		_view = new View({
 			onMark: _onMark,
 			onMeasure: _onMeasure,
+			markSelector: _markSelector,
+			elementSelector: _elementSelector,
 			startMarkName: _startMarkName,
 			zoneConfigs,
 		});

--- a/src/View.js
+++ b/src/View.js
@@ -26,6 +26,8 @@ export default class View extends UXBase {
 		return new Zone({
 			onMark: this.props.onMark,
 			onMeasure: this.props.onMeasure,
+			markSelector: this.props.markSelector,
+			elementSelector: this.props.elementSelector,
 			startMarkName: this.props.startMarkName,
 			...zoneConfig,
 		});

--- a/src/View.js
+++ b/src/View.js
@@ -26,6 +26,7 @@ export default class View extends UXBase {
 		return new Zone({
 			onMark: this.props.onMark,
 			onMeasure: this.props.onMeasure,
+			startMarkName: this.props.startMarkName,
 			...zoneConfig,
 		});
 	}

--- a/src/Zone.js
+++ b/src/Zone.js
@@ -19,19 +19,39 @@ export default class Zone extends UXBase {
 	measureName = this.props.name;
 
 	// Create a new `ExpectedMark` for each mark
-	marks = this.props.marks.map(markName => {
-		const mark = ExpectedMark.create(markName);
+	marks = this.props.elements
+		? // new elements array on zone object
+		  this.props.elements
+				.map(element =>
+					element.marks.map(markName => {
+						const mark = ExpectedMark.create(markName);
 
-		mark.onComplete(completeMark => {
-			// pass the event upstream
-			this.props.onMark(markName);
-			if (this.marks.every(m => m.marked)) {
-				this.measure(markName);
-			}
-		});
+						mark.onComplete(completeMark => {
+							// pass the event upstream
+							this.props.onMark(markName);
+							if (this.marks.every(m => m.marked)) {
+								this.measure(markName);
+							}
+						});
 
-		return mark;
-	});
+						return mark;
+					})
+				)
+				.flat()
+		: // legacy with direct marks array on zone object
+		  this.props.marks.map(markName => {
+				const mark = ExpectedMark.create(markName);
+
+				mark.onComplete(completeMark => {
+					// pass the event upstream
+					this.props.onMark(markName);
+					if (this.marks.every(m => m.marked)) {
+						this.measure(markName);
+					}
+				});
+
+				return mark;
+		  });
 
 	/**
 	 * Records measure on Performance Timeline and calls onMeasure callback

--- a/src/Zone.js
+++ b/src/Zone.js
@@ -1,6 +1,8 @@
 import ExpectedMark from './ExpectedMark';
 import UXBase from './UXBase';
 
+import { INTERACTIVE_TRANSITION_START_MARK_NAME } from './UXCapture';
+
 /**
  * A `Zone` is a collection of DOM elements on a page that correspond
  * to a given phase of page load. (e.g. all elements in `ux-destination-verfied`)
@@ -18,40 +20,77 @@ export default class Zone extends UXBase {
 	// Name used for UserTiming measures
 	measureName = this.props.name;
 
-	// Create a new `ExpectedMark` for each mark
-	marks = this.props.elements
-		? // new elements array on zone object
-		  this.props.elements
-				.map(element =>
-					element.marks.map(markName => {
-						const mark = ExpectedMark.create(markName);
+	constructor(props) {
+		super(props);
 
-						mark.onComplete(completeMark => {
-							// pass the event upstream
-							this.props.onMark(markName);
-							if (this.marks.every(m => m.marked)) {
-								this.measure(markName);
-							}
-						});
+		// Create a new `ExpectedMark` for each mark
+		const configuredMarkNames = this.props.elements
+			? // new elements array on zone object
+			  this.props.elements.map(element => element.marks).flat()
+			: // legacy with direct marks array on zone object
+			  this.props.marks;
 
-						return mark;
-					})
-				)
-				.flat()
-		: // legacy with direct marks array on zone object
-		  this.props.marks.map(markName => {
-				const mark = ExpectedMark.create(markName);
+		// mark names for elements already on the page
+		let alreadyOnThePage = [];
 
-				mark.onComplete(completeMark => {
-					// pass the event upstream
-					this.props.onMark(markName);
-					if (this.marks.every(m => m.marked)) {
-						this.measure(markName);
+		if (this.props.startMarkName === INTERACTIVE_TRANSITION_START_MARK_NAME) {
+			// if mark selector is configured, use it to find marks to record
+			if (props.markSelector) {
+				alreadyOnThePage.concat(
+					configuredMarkNames.filter(
+						markName => props.markSelector(markName).length > 0
+					)
+				);
+			}
+
+			// if elements have selectors defined or global element selector is configured,
+			// use them to find marks to record
+			props.elements.forEach(element => {
+				let elementFound = false;
+
+				if (element.elementSelector) {
+					if (typeof element.elementSelector === 'function') {
+						elementFound = element.elementSelector().length > 0;
+					} else {
+						elementFound =
+							document.querySelectorAll(element.elementSelector).length > 0;
 					}
-				});
+				} else if (this.props.elementSelector) {
+					elementFound = this.props.elementSelector(element).length > 0;
+				}
 
-				return mark;
-		  });
+				if (elementFound) {
+					alreadyOnThePage = alreadyOnThePage.concat(element.marks);
+				}
+			});
+		}
+
+		// do not create marks for elements that are already on the page
+		const markNamesToExpect = configuredMarkNames.filter(
+			markName =>
+				!alreadyOnThePage.find(existingMarkName => existingMarkName === markName)
+		);
+
+		this.marks = markNamesToExpect.map(markName => {
+			const mark = ExpectedMark.create(markName);
+
+			mark.onComplete(completeMark => {
+				// pass the event upstream
+				this.props.onMark(markName);
+				if (this.marks.every(m => m.marked)) {
+					this.measure(markName);
+				}
+			});
+
+			return mark;
+		});
+
+		// if expected some marks, but all are already on the page,
+		// create zero-length measure
+		if (configuredMarkNames.length > 0 && markNamesToExpect.length === 0) {
+			this.measure(this.props.startMarkName);
+		}
+	}
 
 	/**
 	 * Records measure on Performance Timeline and calls onMeasure callback

--- a/src/Zone.js
+++ b/src/Zone.js
@@ -10,15 +10,13 @@ import UXBase from './UXBase';
  * {
  *  name: "ux-destination-verified",
  *  marks: ["ux-image-online-logo", "ux-image-inline-logo"]
- *  onMeasure: measureName => {}
+ *  onMeasure: measureName => {},
  *  onMark: markName => {}
  * }
  */
 export default class Zone extends UXBase {
 	// Name used for UserTiming measures
 	measureName = this.props.name;
-
-	startMark = 'navigationStart';
 
 	// Create a new `ExpectedMark` for each mark
 	marks = this.props.marks.map(markName => {
@@ -45,7 +43,11 @@ export default class Zone extends UXBase {
 			typeof window.performance !== 'undefined' &&
 			typeof window.performance.measure !== 'undefined'
 		) {
-			window.performance.measure(this.measureName, this.startMark, endMarkName);
+			window.performance.measure(
+				this.measureName,
+				this.props.startMarkName,
+				endMarkName
+			);
 		}
 
 		this.props.onMeasure(this.measureName);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,27 +1,28 @@
-const webpack = require("webpack"); // to access built-in plugins
-const path = require("path");
+const webpack = require('webpack'); // to access built-in plugins
+const path = require('path');
 
 module.exports = {
-  entry: "./src/ux-capture.js",
-  mode: "production",
-  output: {
-    filename: "ux-capture.min.js",
-    path: path.resolve(__dirname, "lib")
-  },
-  module: {
-    rules: [
-      {
-        enforce: "pre",
-        test: /\.js$/,
-        exclude: /node_modules/,
-        loader: "eslint-loader"
-      },
-      {
-        test: /\.js$/,
-        exclude: /node_modules/,
-        use: "babel-loader"
-      }
-    ]
-  },
-  plugins: [new webpack.ProgressPlugin()]
+	entry: './src/ux-capture.js',
+	devtool: 'source-map',
+	mode: 'production',
+	output: {
+		filename: 'ux-capture.min.js',
+		path: path.resolve(__dirname, 'lib'),
+	},
+	module: {
+		rules: [
+			{
+				enforce: 'pre',
+				test: /\.js$/,
+				exclude: /node_modules/,
+				loader: 'eslint-loader',
+			},
+			{
+				test: /\.js$/,
+				exclude: /node_modules/,
+				use: 'babel-loader',
+			},
+		],
+	},
+	plugins: [new webpack.ProgressPlugin()],
 };


### PR DESCRIPTION
Prototype of selectors logic with support for all 3 ways of defining selectors:
1. individual `elementSelector` on each `element` entry (either a `string` for CSS selector or a `function`)
2. `elementSelector` configuration setting passed to `UXCapture.create()` accepts element as an argument
3. `markSelector` configuration setting passed to `UXCapture.create()` accepts mark as an argument (does not require zone configuration to have element abstraction layer)

Also includes configuration example pages with micro SPA implementation.

JIRA: https://meetup.atlassian.net/browse/WP-946